### PR TITLE
Fix/simplify parsers

### DIFF
--- a/resources/schema.edn
+++ b/resources/schema.edn
@@ -94,12 +94,11 @@
                              :createdOn                          {:type (non-null :BigInt)}
                              :treesFileUrl                       {:type (non-null String)}
                              :sliceHeightsFileUrl                {:type String}
-                             :burnIn                             {:type Int}
+                             :burnIn                             {:type Float}
                              :relaxedRandomWalkRateAttributeName {:type String}
                              :traitAttributeName                 {:type String}
                              :contouringGridSize                 {:type Int}
                              :numberOfIntervals                  {:type Int}
-                             :treesCount                         {:type Int}
                              :hpdLevel                           {:type String}
                              :timescaleMultiplier                {:type Float}
                              :mostRecentSamplingDate             {:type String}
@@ -253,7 +252,7 @@
                      :description "Updates the entity with settings for parsing."
                      :args        {:id                                 {:type (non-null ID)}
                                    :readableName                       {:type String}
-                                   :burnIn                             {:type Int}
+                                   :burnIn                             {:type Float}
                                    :relaxedRandomWalkRateAttributeName {:type (non-null String)}
                                    :traitAttributeName                 {:type (non-null String)}
                                    :contouringGridSize                 {:type Int}

--- a/resources/sql/time_slicer.sql
+++ b/resources/sql/time_slicer.sql
@@ -38,8 +38,7 @@ contouring_grid_size = IF(:contouring-grid-size IS NOT NULL, :contouring-grid-si
 hpd_level = IF(:hpd-level IS NOT NULL, :hpd-level, hpd_level),
 timescale_multiplier = IF(:timescale-multiplier IS NOT NULL, :timescale-multiplier, timescale_multiplier),
 most_recent_sampling_date = IF(:most-recent-sampling-date IS NOT NULL, :most-recent-sampling-date, most_recent_sampling_date),
-output_file_url = IF(:output-file-url IS NOT NULL, :output-file-url, output_file_url),
-trees_count = IF(:trees-count IS NOT NULL, :trees-count, trees_count)
+output_file_url = IF(:output-file-url IS NOT NULL, :output-file-url, output_file_url)
 WHERE id = :id
 
 -- :name get-time-slicer :? :1
@@ -61,7 +60,6 @@ hpd_level,
 timescale_multiplier,
 most_recent_sampling_date,
 output_file_url,
-trees_count,
 status,
 progress
 FROM time_slicer

--- a/services/db-migration/src/main/resources/liquibase/db.changelog-4.0.xml
+++ b/services/db-migration/src/main/resources/liquibase/db.changelog-4.0.xml
@@ -25,7 +25,6 @@
       <column name="contouring_grid_size" type="INT"/>
       <column name="timescale_multiplier" type="FLOAT"/>
       <column name="most_recent_sampling_date" type="VARCHAR(20)"/>
-      <column name="trees_count" type="INT"/>
       <column name="created_on" type="BIGINT">
         <constraints nullable="false"/>
       </column>

--- a/services/db-migration/src/main/resources/liquibase/db.changelog-4.0.xml
+++ b/services/db-migration/src/main/resources/liquibase/db.changelog-4.0.xml
@@ -15,7 +15,7 @@
         <constraints nullable="false" />
       </column>
       <column name="slice_heights_file_url" type="VARCHAR(200)"/>
-      <column name="burn_in" type="INT"/>
+      <column name="burn_in" type="FLOAT"/>
       <column name="number_of_intervals" type="INT"/>
       <column name="output_file_url" type="VARCHAR(200)"/>
       <column name="readable_name" type="VARCHAR(200)"/>

--- a/src/clj/api/models/time_slicer.clj
+++ b/src/clj/api/models/time_slicer.clj
@@ -29,8 +29,7 @@
    :contouring-grid-size                    nil
    :timescale-multiplier                    nil
    :most-recent-sampling-date               nil
-   :output-file-url                         nil
-   :trees-count                             nil})
+   :output-file-url                         nil})
 
 (defn upsert! [db time-slicer]
   (let [time-slicer (->> time-slicer

--- a/src/clj/tests/integration/time_slicer_test.clj
+++ b/src/clj/tests/integration/time_slicer_test.clj
@@ -53,20 +53,19 @@
 
         _ (block-on-status id :ATTRIBUTES_PARSED)
 
-        {:keys [id attributeNames treesCount]} (get-in (run-query {:query
-                                                                   "query GetTree($id: ID!) {
+        {:keys [id attributeNames]} (get-in (run-query {:query
+                                                        "query GetTree($id: ID!) {
                                                                             getTimeSlicer(id: $id) {
                                                                               id
-                                                                              treesCount
                                                                               attributeNames
                                                                             }
                                                                           }"
-                                                                   :variables {:id id}})
-                                                       [:data :getTimeSlicer])
+                                                        :variables {:id id}})
+                                            [:data :getTimeSlicer])
 
         {:keys [status]} (get-in (run-query {:query
                                              "mutation UpdateTree($id: ID!,
-                                                                  $burnIn: Int!,
+                                                                  $burnIn: Float!,
                                                                   $numberOfIntervals : Int!,
                                                                   $rrwRateAttributeName: String!,
                                                                   $traitAttributeName: String!,
@@ -88,7 +87,7 @@
                                                          :traitAttributeName   "location"
                                                          :rrwRateAttributeName "rate"
                                                          :contouringGridSize   100
-                                                         :burnIn               1
+                                                         :burnIn               0.1
                                                          :numberOfIntervals    10
                                                          :hpd                  0.8
                                                          :mrsd                 "2021/01/12"}})
@@ -132,6 +131,5 @@
     (is (= (:dd (time/now))
            (:dd (time/from-millis createdOn))))
     (is #{"rate" "location"} (set attributeNames))
-    (is (= 10 treesCount))
     (is (= 1.0 progress))
     (is outputFileUrl)))

--- a/src/test/java/com/spread/TimeSlicerParserTest.java
+++ b/src/test/java/com/spread/TimeSlicerParserTest.java
@@ -9,12 +9,16 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
 import com.spread.data.SpreadData;
 import com.spread.exceptions.SpreadException;
 import com.spread.data.Attribute;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 
 import com.spread.parsers.TimeSlicerParser;
 import com.spread.utils.ParsersUtils;
@@ -24,13 +28,15 @@ public class TimeSlicerParserTest {
     @Test
     public void runTest() throws IOException, ImportException, SpreadException {
 
+        Gson gson = new Gson();
+
         String mostRecentSamplingDate = "2021/01/12";
         double hpdLevel = 0.8;
         String path = "timeSlicer/WNV_small.trees";
         File treesfile = new File(getClass().getClassLoader().getResource(path).getFile());
 
         TimeSlicerParser parser = new TimeSlicerParser (treesfile.getAbsolutePath(),
-                                                        1,
+                                                        0.1,
                                                         10,
                                                         "location",
                                                         "rate",
@@ -39,12 +45,16 @@ public class TimeSlicerParserTest {
                                                         mostRecentSamplingDate,
                                                         1.0);
 
+        Set<String> expectedAttributes = new HashSet<>(Arrays.asList("rate", "location"));
+        Set<String> uniqueAttributes = gson.fromJson(parser.parseAttributes(), new TypeToken<Set<String>>(){}.getType());
+
+        assertEquals("attributes are parsed", expectedAttributes, uniqueAttributes);
+
         ConsoleProgressObserver progressObserver = new ConsoleProgressObserver();
         parser.registerProgressObserver(progressObserver);
         progressObserver.start ();
 
         String json = parser.parse();
-        Gson gson = new Gson();
         SpreadData data = gson.fromJson(json, SpreadData.class);
 
         assertEquals("returns correct mrsd", mostRecentSamplingDate, data.getTimeLine().getEndTime());


### PR DESCRIPTION
### Summary

change time-slicer parser to accept burnIn attribute in [0,1] (to match bayes factor parser). This makes treesCount in the log file opaque to the user.