### PR TITLE
Analysis viewer dev

### DIFF
--- a/services/analysis-viewer/css/components.css
+++ b/services/analysis-viewer/css/components.css
@@ -1,3 +1,7 @@
+/*****************/
+/* Switch button */
+/*****************/
+
 .switch-button {
 	position: relative;
     width: 56px;
@@ -42,4 +46,29 @@
     position: relative;
 	top: 7px;
 	left: 15px;
+}
+
+/**********/
+/* Slider */
+/**********/
+
+.slider {
+	display: inline-flex;
+	flex-direction: column;
+	margin-right: 15px;
+    margin-left: 15px;
+	width: 22px;
+	height: 164px;
+	justify-content: center;    
+}
+
+.slider button {
+	padding: 1px 6px 1px 6px;
+	color: #3A3668;
+	background-color: #DEDEE8;
+	border-radius: 3px;
+}
+
+.slider svg {
+	height: 100px;
 }

--- a/services/analysis-viewer/css/components.css
+++ b/services/analysis-viewer/css/components.css
@@ -56,8 +56,7 @@
 	display: inline-flex;
 	flex-direction: column;
 	margin-right: 15px;
-    margin-left: 15px;
-	width: 22px;
+    margin-left: 15px;    
     justify-content: center;    
 }
 

--- a/services/analysis-viewer/css/components.css
+++ b/services/analysis-viewer/css/components.css
@@ -1,0 +1,45 @@
+.switch-button {
+	position: relative;
+    width: 56px;
+	height: 24px;
+    cursor: pointer;
+	color: white;
+	font-size: 11px;
+	border-radius: 6px;
+}
+
+.switch-button.on{
+	background-color: #EEBE53;
+}
+.switch-button.off{
+	background-color: grey;
+}
+.switch-button span.on {
+    position: relative;
+	top: 7px;
+	left: 9px;
+}
+.switch-button .block {
+	display: inline-block;
+    position: absolute;
+    top: 3px;
+    left: 7px;
+    width: 17px;
+    height: 17px;
+    background-color: white;
+    border-radius: 4px;
+}
+
+.switch-button .block.block-off {
+    left: 7px;
+}
+
+.switch-button .block.block-on {
+	left: 29px;
+}
+
+.switch-button span.off {
+    position: relative;
+	top: 7px;
+	left: 15px;
+}

--- a/services/analysis-viewer/css/components.css
+++ b/services/analysis-viewer/css/components.css
@@ -58,8 +58,7 @@
 	margin-right: 15px;
     margin-left: 15px;
 	width: 22px;
-	height: 164px;
-	justify-content: center;    
+    justify-content: center;    
 }
 
 .slider button {
@@ -69,6 +68,20 @@
 	border-radius: 3px;
 }
 
-.slider svg {
-	height: 100px;
+.slider .outer {
+    display: flex;
 }
+
+.slider .outer.vertical {
+    flex-direction: column;
+}
+
+.slider .outer.horizontal{
+    flex-direction: row;
+}
+
+.slider button{
+    width: 20px;
+	height: 20px;
+}
+

--- a/services/analysis-viewer/css/main.css
+++ b/services/analysis-viewer/css/main.css
@@ -182,11 +182,12 @@ button {
 /*****************/
 
 .animated-data-map {
-	grid-area: animated-data-map;       
+	grid-area: animated-data-map;
+	width: 99%;
 }
 
 
-.animated-data-map > svg {
+.animated-data-map > .map-wrapper {
 	height: calc(100% - 204px - 4px); /*substract the animation-controls height*/
 }
 

--- a/services/analysis-viewer/css/main.css
+++ b/services/analysis-viewer/css/main.css
@@ -184,6 +184,7 @@ button {
 .animated-data-map {
 	grid-area: animated-data-map;
 	width: 99%;
+	position: relative;
 }
 
 
@@ -214,6 +215,29 @@ button {
 	border-radius: 10px;
 	opacity: 0.5;
 	z-index: 0;
+}
+
+.pop-up {
+	position: absolute;
+    background-color: white;
+	border: 1px solid #DEDEE8;
+	padding: 5px;
+	max-width: 300px;
+	max-height: 200px;
+	font-size: 10px;
+}
+
+.pop-up label {
+	font-weight: bold;
+	color: #3A3668;
+	margin-right: 3px;
+	
+}
+
+.possible-objects-popup .selectable-object {
+	font-weight: bold;
+	color: #3A3668;
+	cursor: pointer;
 }
 
 /**********************/

--- a/services/analysis-viewer/css/main.css
+++ b/services/analysis-viewer/css/main.css
@@ -140,6 +140,33 @@ button {
 }
 
 /*****************/
+/* Color chooser */
+/*****************/
+.map-color-chooser {
+    display:flex;
+	justify-content: center;    
+}
+.map-color-chooser .colors {
+	display: grid;
+	grid-template-columns: 22px 22px 22px 22px 22px 22px 22px 22px 22px;
+	grid-column-gap: 4px;
+	grid-row-gap: 4px;
+	margin: 10px;
+}
+
+.map-color-chooser .color {
+	cursor: pointer;
+	width: 21px;
+	height: 22px;
+	border-radius: 5px;
+	border: 1px solid #E2E2EA;
+	text-align: center;    
+}
+.color i {
+	margin-top: 4px;
+}
+
+/*****************/
 /* Animated map  */
 /*****************/
 

--- a/services/analysis-viewer/css/main.css
+++ b/services/analysis-viewer/css/main.css
@@ -244,27 +244,3 @@ button {
 .animation-controls .inner .buttons i.zmdi-play{
 	font-size: 40px;    
 }
-
-/**********************/
-/* General components */
-/**********************/
-.zoom-bar {
-	display: inline-flex;
-	flex-direction: column;
-	margin-right: 15px;
-    margin-left: 15px;
-	width: 22px;
-	height: 164px;
-	justify-content: center;    
-}
-
-.zoom-bar button {
-	padding: 1px 6px 1px 6px;
-	color: #3A3668;
-	background-color: #DEDEE8;
-	border-radius: 3px;
-}
-
-.zoom-bar svg {
-	height: 100px;
-}

--- a/services/analysis-viewer/css/main.css
+++ b/services/analysis-viewer/css/main.css
@@ -164,6 +164,12 @@ button {
 	margin-top: 4px;
 }
 
+.attribute-color-chooser {
+	display: flex;
+	width: 100%;
+	justify-content: space-between;
+}
+
 /*******************/
 /* Layers settings */
 /*******************/
@@ -211,6 +217,10 @@ button {
 	flex-direction: column;
 }
 
+.circles-settings .attribute-color-chooser {
+	margin-bottom:12px;
+}
+
 /********************/
 /* Nodes settings */
 /********************/
@@ -219,6 +229,10 @@ button {
 	align-items: center;
 	flex-direction: column;
 }
+.nodes-settings .attribute-color-chooser {
+	margin-bottom:12px;
+}
+
 
 /************************/
 /* Transitions settings */
@@ -230,6 +244,9 @@ button {
 	align-items: center;
 }
 
+.transitions-settings .attribute-color-chooser {
+	margin-bottom:12px;
+}
 /*****************/
 /* Animated map  */
 /*****************/
@@ -321,3 +338,4 @@ button {
 .animation-controls .inner .buttons i.zmdi-play{
 	font-size: 40px;    
 }
+

--- a/services/analysis-viewer/css/main.css
+++ b/services/analysis-viewer/css/main.css
@@ -137,16 +137,14 @@ button {
 
 .collapsible-tabs .tab-body.collapsed {
 	height: 0;
+	padding: 0;
 }
 
 /*****************/
 /* Color chooser */
 /*****************/
-.map-color-chooser {
-    display:flex;
-	justify-content: center;    
-}
-.map-color-chooser .colors {
+
+.colors {
 	display: grid;
 	grid-template-columns: 22px 22px 22px 22px 22px 22px 22px 22px 22px;
 	grid-column-gap: 4px;
@@ -154,7 +152,7 @@ button {
 	margin: 10px;
 }
 
-.map-color-chooser .color {
+.color {
 	cursor: pointer;
 	width: 21px;
 	height: 22px;
@@ -166,15 +164,70 @@ button {
 	margin-top: 4px;
 }
 
-/********************/
-/* Layer visibility */
-/********************/
+/*******************/
+/* Layers settings */
+/*******************/
 
-.layer-visibility {
+.layers-settings {
 	display: grid;
     grid-template-columns: 70% 30%;
     grid-row-gap: 9px;
 	font-size: 14px;
+}
+
+/****************/
+/* Map settings */
+/****************/
+
+.map-settings {
+    display:flex;
+	justify-content: center;    
+}
+
+/********************/
+/* Polygon settings */
+/********************/
+.polygons-settings {
+    display:flex;
+	align-items: center;
+	flex-direction: column;
+}
+
+/********************/
+/* Labels settings */
+/********************/
+.labels-settings {
+    display:flex;
+	align-items: center;
+	flex-direction: column;
+}
+
+/********************/
+/* Circle settings */
+/********************/
+.circles-settings {
+    display:flex;
+	align-items: center;
+	flex-direction: column;
+}
+
+/********************/
+/* Nodes settings */
+/********************/
+.nodes-settings {
+    display:flex;
+	align-items: center;
+	flex-direction: column;
+}
+
+/************************/
+/* Transitions settings */
+/************************/
+
+.transitions-settings {
+    display: flex;
+	flex-direction: column;
+	align-items: center;
 }
 
 /*****************/

--- a/services/analysis-viewer/css/main.css
+++ b/services/analysis-viewer/css/main.css
@@ -100,6 +100,7 @@ button {
 	display: flex;
     flex-direction: column;
     justify-content: space-between;
+	color: #3A3668;
 }
 
 .export-panel {
@@ -109,7 +110,6 @@ button {
 } 
 
 .collapsible-tabs > .title {
-	color: #3A3668;
     font-weight: bold;
 	text-align: center;
 	border-bottom: 1px solid #E2E2EA;
@@ -120,7 +120,6 @@ button {
 .collapsible-tabs > .tabs > .tab > .title {
 	display: flex;
 	justify-content: space-between;	
-	color: #3A3668;
     border-bottom: 1px solid #E2E2EA;
 	border-top: 1px solid #E2E2EA;
     padding: 15px 15px 15px 15px;
@@ -164,6 +163,18 @@ button {
 }
 .color i {
 	margin-top: 4px;
+}
+
+/********************/
+/* Layer visibility */
+/********************/
+
+.layer-visibility {
+	display: grid;
+    grid-template-columns: 60% 40%;
+    padding: 17px;
+    grid-row-gap: 9px;
+	font-size: 14px;
 }
 
 /*****************/

--- a/services/analysis-viewer/css/main.css
+++ b/services/analysis-viewer/css/main.css
@@ -152,6 +152,31 @@ button {
 	height: calc(100% - 204px - 4px); /*substract the animation-controls height*/
 }
 
+.map-zoom {
+	position: absolute;
+	top: 0;
+	left: 0;
+	z-index: 10;
+}
+.zoom-bar-outer {
+	position: relative;
+	top: 10px;
+	left: 10px;
+	border-radius: 10px;    
+}
+
+.zoom-bar-outer .zoom-bar-back {
+	position: absolute;
+	top: 0;
+	left: 5px;
+    width: 43px;
+    height: 165px;
+	background-color: #757295;
+	border-radius: 10px;
+	opacity: 0.5;
+	z-index: 0;
+}
+
 /**********************/
 /* Animation controls */
 /**********************/
@@ -177,26 +202,30 @@ button {
 	color: #3A3668;
 }
 
-.animation-controls .anim-bar-zoom {
+.animation-controls .inner .buttons i.zmdi-play{
+	font-size: 40px;    
+}
+
+/**********************/
+/* General components */
+/**********************/
+.zoom-bar {
 	display: inline-flex;
 	flex-direction: column;
 	margin-right: 15px;
     margin-left: 15px;
 	width: 22px;
 	height: 164px;
-	justify-content: center;
+	justify-content: center;    
 }
 
-.animation-controls .anim-bar-zoom button {
+.zoom-bar button {
 	padding: 1px 6px 1px 6px;
 	color: #3A3668;
 	background-color: #DEDEE8;
 	border-radius: 3px;
 }
 
-.animation-controls .anim-bar-zoom svg {
+.zoom-bar svg {
 	height: 100px;
-}
-.animation-controls .inner .buttons i.zmdi-play{
-	font-size: 40px;    
 }

--- a/services/analysis-viewer/css/main.css
+++ b/services/analysis-viewer/css/main.css
@@ -129,6 +129,7 @@ button {
 
 .collapsible-tabs .tab-body {
     overflow: hidden;
+	padding: 17px;   
 }
 .collapsible-tabs .tab-body.open {
 	height: 100%;
@@ -171,8 +172,7 @@ button {
 
 .layer-visibility {
 	display: grid;
-    grid-template-columns: 60% 40%;
-    padding: 17px;
+    grid-template-columns: 70% 30%;
     grid-row-gap: 9px;
 	font-size: 14px;
 }
@@ -193,7 +193,7 @@ button {
 
 .map-zoom {
 	position: absolute;
-	top: 0;
+	top: 10px;
 	left: 0;
 	z-index: 10;
 }

--- a/services/analysis-viewer/index.html
+++ b/services/analysis-viewer/index.html
@@ -6,6 +6,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@500&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/material-design-iconic-font.min.css">
   <link rel="stylesheet" href="/css/main.css">
+  <link rel="stylesheet" href="/css/components.css">
   <body>
     <div id="app"></div>
     <script src="/js/main.js"></script>

--- a/src/cljc/shared/math_utils.cljc
+++ b/src/cljc/shared/math_utils.cljc
@@ -122,8 +122,8 @@
   [x1 y1 x2 y2 proj-scale]
   (let [map-proj-width  360
         map-proj-height 180
-        scale-x (/ map-proj-width  (max (- x2 x1)))
-        scale-y (/ map-proj-height (max (- y2 y1)))
+        scale-x (/ map-proj-width  (- x2 x1))
+        scale-y (/ map-proj-height (- y2 y1))
         scale (min scale-x scale-y)
         tx    (* -1 scale proj-scale x1)
         ty    (* -1 scale proj-scale y1)]

--- a/src/cljc/shared/math_utils.cljc
+++ b/src/cljc/shared/math_utils.cljc
@@ -55,8 +55,9 @@
         ;; a line perp to `line` that pass thru its center
         center-perp (fn [x] (- (+ (* perp-m x) cy) (* cx perp-m)))
         
-        k 5 ;; we can increase/decrease k to make the arc (focus distance) bigger/smaller
-
+        k 1 ;; we can increase/decrease k to make the arc (focus distance) bigger/smaller
+        length (sqrt (+ (pow (- x2 x1) 2) (pow (- y2 y1) 2)))
+        
         ;; calculates focus x, a point that belongs to `center-perp` line and is at distance `k`
         ;; from `cx`,`cy`
         ;; `sol-fn` can be `+` or `-` to get the fx below and avobe the line

--- a/src/cljc/shared/math_utils.cljc
+++ b/src/cljc/shared/math_utils.cljc
@@ -42,7 +42,7 @@
   
   "Calculates nice focuses (positive and negative) for a quadratic curve given its starting and end points"
   
-  [x1 y1 x2 y2]
+  [x1 y1 x2 y2 curvature]
   (let [line-m (/ (- y1 y2)
                   (- x1 x2))
         ;; the line that goes from [x1,y1] to [x2,y2]
@@ -54,8 +54,7 @@
         cy (line cx)
         ;; a line perp to `line` that pass thru its center
         center-perp (fn [x] (- (+ (* perp-m x) cy) (* cx perp-m)))
-        
-        k 1 ;; we can increase/decrease k to make the arc (focus distance) bigger/smaller
+                
         length (sqrt (+ (pow (- x2 x1) 2) (pow (- y2 y1) 2)))
         
         ;; calculates focus x, a point that belongs to `center-perp` line and is at distance `k`
@@ -69,7 +68,7 @@
                 
                 ;; calculates focus-x, which is the point x that belongs to the perpendicular line
                 ;; that goes thru the center, and also is at distance k from cx,cy
-                (/ (sol-fn (+ (* cx (pow perp-m 2)) cx) (sqrt (* (pow k 2) (+ (pow perp-m 2) 1))))
+                (/ (sol-fn (+ (* cx (pow perp-m 2)) cx) (sqrt (* (pow curvature 2) (+ (pow perp-m 2) 1))))
                    (+ (pow perp-m 2) 1)))
         f1x (fx-fn +)
         f2x (fx-fn -)
@@ -131,4 +130,3 @@
     
     {:translate [tx ty]
      :scale     scale}))
-

--- a/src/cljc/shared/math_utils.cljc
+++ b/src/cljc/shared/math_utils.cljc
@@ -130,3 +130,28 @@
     
     {:translate [tx ty]
      :scale     scale}))
+
+(defn normalize-color-str [color-str]
+  (let [[_ r g b] (re-find #"#(..)(..)(..)" color-str)
+        norm (fn [hex-str] (/ (js/parseInt hex-str 16) 255))]
+    [(norm r) (norm g) (norm b)]))
+
+(defn to-hex [n]
+  (let [s (.toString n 16)]
+    (if (= 1 (count s))
+      (str "0" s)
+      s)))
+
+(defn denormalize-color [[r g b]]  
+  (str "#"
+       (to-hex (int (* 255 r)))
+       (to-hex (int (* 255 g)))
+       (to-hex (int (* 255 b)))))
+
+(defn calculate-color [start end perc]
+  (let [[rs gs bs] (normalize-color-str start)
+        [re ge be] (normalize-color-str end)
+        color (denormalize-color [(+ (* perc rs) (* (- 1 perc) re))
+                                  (+ (* perc gs) (* (- 1 perc) ge))
+                                  (+ (* perc bs) (* (- 1 perc) be))])] 
+    color))

--- a/src/cljs/analysis_viewer/components.cljs
+++ b/src/cljs/analysis_viewer/components.cljs
@@ -10,3 +10,15 @@
      [:span.on "On"]
      [:span.block {:class (if on? "block-on" "block-off")}]
      [:span.off "Off"]]))
+
+(defn slider [{:keys [zoom-perc zoom-inc-fn zoom-dec-fn class]}]
+  [:div.slider {:class class}
+   [:button {:on-click zoom-inc-fn} "+"]
+   [:div {:width "6px" :height "100%"}
+    [:svg 
+     [:line {:x1 "10" :y1 "100" :x2 "10" :y2 "0" :stroke "#DEDEE8" :stroke-width 3}]
+     [:line {:x1 "10" :y1 "100" :x2 "10" :y2 "0" :stroke "#EEBE53" :stroke-width 3
+             :stroke-dasharray 100
+             :stroke-dashoffset zoom-perc}]
+     [:rect {:x "4" :y (str (- zoom-perc 6)) :width "12" :height "12" :fill "white" :stroke "grey"}]]]
+   [:button {:on-click zoom-dec-fn} "-"]])

--- a/src/cljs/analysis_viewer/components.cljs
+++ b/src/cljs/analysis_viewer/components.cljs
@@ -1,7 +1,6 @@
 (ns analysis-viewer.components
   (:require [re-frame.core :refer [dispatch subscribe]]
-            [reagent.core :as r]
-            [goog.string :as gstr]))
+            [reagent.core :as r]))
 
 (defn switch-button [{:keys [id]}]
   (let [on? @(subscribe [:switch-buttons/on? id])]
@@ -60,7 +59,7 @@
                                                                   (- grab-screen-length screen-change)
                                                                   (+ grab-screen-length screen-change))]
                                           (set-new-val (screen-length->val new-screen-length)))))
-                     :on-mouse-up (fn [evt]                                 
+                     :on-mouse-up (fn [_]                                 
                                     (swap! state dissoc :grab-screen-val :grab-screen-length))}        
         [:div.outer {:class (if vertical? "vertical" "horizontal")
                      :style {:width slider-width :height slider-height}}

--- a/src/cljs/analysis_viewer/components.cljs
+++ b/src/cljs/analysis_viewer/components.cljs
@@ -18,7 +18,7 @@
                        :grab-screen-length nil}) ;; if it is vertical? it will store y, x otherwise
         val->screen-length (fn [v] (/ (* (- v min-val) length) (- max-val min-val)))
         screen-length->val (fn [sl]
-                             (let [v (/ (* sl (- max-val min-val)) 100)]
+                             (let [v (/ (* sl (- max-val min-val)) length)]
                                (+ min-val v)))
         gap 5
         start 10]

--- a/src/cljs/analysis_viewer/components.cljs
+++ b/src/cljs/analysis_viewer/components.cljs
@@ -1,0 +1,12 @@
+(ns analysis-viewer.components
+  (:require [re-frame.core :refer [dispatch subscribe]]))
+
+(defn switch-button [{:keys [id]}]
+  (let [on? @(subscribe [:switch-buttons/on? id])]
+    [:div.switch-button {:class (if on? "on" "off")
+                         :on-click (fn [evt]
+                                     (.stopPropagation evt)
+                                     (dispatch [:switch-button/toggle id]))}
+     [:span.on "On"]
+     [:span.block {:class (if on? "block-on" "block-off")}]
+     [:span.off "Off"]]))

--- a/src/cljs/analysis_viewer/components.cljs
+++ b/src/cljs/analysis_viewer/components.cljs
@@ -1,5 +1,7 @@
 (ns analysis-viewer.components
-  (:require [re-frame.core :refer [dispatch subscribe]]))
+  (:require [re-frame.core :refer [dispatch subscribe]]
+            [reagent.core :as r]
+            [goog.string :as gstr]))
 
 (defn switch-button [{:keys [id]}]
   (let [on? @(subscribe [:switch-buttons/on? id])]
@@ -11,14 +13,61 @@
      [:span.block {:class (if on? "block-on" "block-off")}]
      [:span.off "Off"]]))
 
-(defn slider [{:keys [zoom-perc zoom-inc-fn zoom-dec-fn class]}]
-  [:div.slider {:class class}
-   [:button {:on-click zoom-inc-fn} "+"]
-   [:div {:width "6px" :height "100%"}
-    [:svg 
-     [:line {:x1 "10" :y1 "100" :x2 "10" :y2 "0" :stroke "#DEDEE8" :stroke-width 3}]
-     [:line {:x1 "10" :y1 "100" :x2 "10" :y2 "0" :stroke "#EEBE53" :stroke-width 3
-             :stroke-dasharray 100
-             :stroke-dashoffset zoom-perc}]
-     [:rect {:x "4" :y (str (- zoom-perc 6)) :width "12" :height "12" :fill "white" :stroke "grey"}]]]
-   [:button {:on-click zoom-dec-fn} "-"]])
+(defn slider [{:keys [inc-buttons length vertical? subs-vec ev-vec min-val max-val  class]}]
+  (let [state (r/atom {:grab-screen-val nil
+                       :grab-screen-length nil}) ;; if it is vertical? it will store y, x otherwise
+        val->screen-length (fn [v] (/ (* (- v min-val) length) (- max-val min-val)))
+        screen-length->val (fn [sl]
+                             (let [v (/ (* sl (- max-val min-val)) 100)]
+                               (+ min-val v)))
+        gap 5
+        start 10]
+    (fn []
+      (let [{:keys [grab-screen-val grab-screen-length]} @state
+            val @(subscribe subs-vec)
+            screen-length (val->screen-length val)
+            line-props (if vertical?
+                         {:x1 start :y1 (- length gap) :x2 start :y2 gap :stroke-width 3
+                          :stroke-dashoffset (- length screen-length)}
+                         {:x1 (- length gap) :y1 start :x2 gap :y2 start :stroke-width 3
+                          :stroke-dashoffset (+ length screen-length)})
+            buttons-extra-size (if inc-buttons 40 0)
+            slider-width  (str (if vertical? 20 (+ length buttons-extra-size)) "px")
+            slider-height (str (if vertical? (+ length buttons-extra-size) 20) "px")
+            block-x (if vertical? 4 (- screen-length start))
+            block-y (if vertical? (- length screen-length 6) 4)
+            set-new-val (fn [new-val]
+                          (when (<= min-val new-val max-val)
+                            (dispatch (conj ev-vec new-val))))
+            inc-btn [:button.plus {:on-click #(set-new-val (+ val inc-buttons))} "+"]
+            dec-btn [:button.plus {:on-click #(set-new-val (- val inc-buttons))} "-"]]
+       [:div.slider {:class class                     
+                     :on-mouse-move (fn [evt]
+                                      (when grab-screen-val
+                                        (let [new-coord-val (if vertical?
+                                                              (-> evt .-nativeEvent .-offsetY)
+                                                              (-> evt .-nativeEvent .-offsetX))
+                                              screen-change (- new-coord-val grab-screen-val)
+                                              new-screen-length (if vertical?
+                                                                  (- grab-screen-length screen-change)
+                                                                  (+ grab-screen-length screen-change))]
+                                          (set-new-val (screen-length->val new-screen-length)))))
+                     :on-mouse-up (fn [evt]                                 
+                                    (swap! state dissoc :grab-screen-val :grab-screen-length))}        
+        [:div.outer {:class (if vertical? "vertical" "horizontal")
+                     :style {:width slider-width :height slider-height}}
+         (when inc-buttons (if vertical? inc-btn dec-btn))
+         [:svg {:width slider-width :height slider-height}
+          [:line (assoc line-props :stroke "#DEDEE8")]
+          [:line (assoc line-props
+                        :stroke "#EEBE53"
+                        :stroke-dasharray length)]
+          [:rect {:x block-x
+                  :y block-y
+                  :width 12 :height 12 :fill "white" :stroke "grey"
+                  :on-mouse-down (fn [evt]
+                                   (let [coord (if vertical?
+                                                 (-> evt .-nativeEvent .-offsetY)
+                                                 (-> evt .-nativeEvent .-offsetX))]                                     
+                                     (swap! state assoc :grab-screen-val coord :grab-screen-length screen-length)))}]]
+         (when inc-buttons (if vertical? dec-btn inc-btn))]]))))

--- a/src/cljs/analysis_viewer/components.cljs
+++ b/src/cljs/analysis_viewer/components.cljs
@@ -13,7 +13,15 @@
      [:span.block {:class (if on? "block-on" "block-off")}]
      [:span.off "Off"]]))
 
-(defn slider [{:keys [inc-buttons length vertical? subs-vec ev-vec min-val max-val  class]}]
+(defn slider
+  "Re-frame friendly vertical slider.
+  vertical? - When true will be drawed vertically
+  length - the length in pixels of the slider line
+  subs-vec - A subscription vector from where the component should read the current value
+  ev-vec - A event vector that is going to be dispatched with the new value everytime the slider changes
+  min-val, max-val - The limits of the value read using subs-vec and set by ev-vec
+  inc-buttons - [OPTIONAL] When a number will render a +/- buttons that increment/decrement the slider by this amount"
+  [{:keys [inc-buttons length vertical? subs-vec ev-vec min-val max-val  class]}]
   (let [state (r/atom {:grab-screen-val nil
                        :grab-screen-length nil}) ;; if it is vertical? it will store y, x otherwise
         val->screen-length (fn [v] (/ (* (- v min-val) length) (- max-val min-val)))

--- a/src/cljs/analysis_viewer/db.cljs
+++ b/src/cljs/analysis_viewer/db.cljs
@@ -7,9 +7,13 @@
 (s/def :map/translate :cartesian/coord)
 (s/def :map/screen-current :cartesian/coord)
 (s/def :map/grab (s/keys :req-un [:map/screen-current]))
+(s/def :map/width (s/nilable number?))
+(s/def :map/height (s/nilable number?))
 (s/def :map/state (s/keys :req-un [:map/scale
                                    :map/translate]
-                          :opt-un [:map/grab]))
+                          :opt-un [:map/grab
+                                   :map/width
+                                   :map/height]))
 
 (s/def :map/url string?)
 (s/def :map/z-index number?)
@@ -39,7 +43,9 @@
 
 (defn initial-db []
   {:map/state {:scale 1
-               :translate [0 0]}
+               :translate [0 0]
+               :width nil
+               :height nil}
    :animation/percentage 0
    :animation/state :stop
    :ui.collapsible-tabs/tabs {:parameters {:layer-visibility true,

--- a/src/cljs/analysis_viewer/db.cljs
+++ b/src/cljs/analysis_viewer/db.cljs
@@ -20,13 +20,16 @@
 (s/def :analysis/data any?) ;; TODO: I think this can be specified
 
 (s/def :ui.collapsible-tabs/tabs (s/nilable (s/map-of keyword? (s/map-of keyword? boolean?))))
+(s/def :ui/parameters map?)
 
 (s/def ::db (s/keys :req [:map/state
-                          :ui.collapsible-tabs/tabs]
+                          :ui.collapsible-tabs/tabs
+                          :ui/parameters]
                     :opt [:map/data
                           :analysis/data]))
 
 (defn initial-db []
   {:map/state {:scale 1
                :translate [0 0]}
-   :ui.collapsible-tabs/tabs {}})
+   :ui.collapsible-tabs/tabs {}
+   :ui/parameters {:map-borders-color "#079DAB"}})

--- a/src/cljs/analysis_viewer/db.cljs
+++ b/src/cljs/analysis_viewer/db.cljs
@@ -20,7 +20,9 @@
 (s/def :map/geo-json any?)
 (s/def :map/data (s/keys :req [:map/url :map/z-index :map/geo-json]))
 (s/def :maps/data (s/coll-of :map/data))
-(s/def :analysis/data any?) ;; TODO: I think this can be specified
+(s/def :analysis.data/object any?) ;; TODO: I think this can be specified
+(s/def :analysis.data.object/id string?)
+(s/def :analysis/data (s/map-of :analysis.data.object/id :analysis.data/object)) 
 
 (s/def :ui.collapsible-tabs/tabs (s/map-of keyword? (s/map-of keyword? boolean?)))
 (s/def :ui.switch-buttons/states (s/map-of keyword? boolean?))
@@ -32,14 +34,21 @@
 (s/def :animation/percentage (s/and number? #(<= 0 % 1)))
 (s/def :animation/state #{:stop :play})
 
-(s/def ::db (s/keys :req [:map/state
+(s/def :analysis/selected-object-id :analysis.data.object/id)
+(s/def :analysis/possible-objects-ids (s/coll-of :analysis.data.object/id))
+(s/def :map/popup-coord :cartesian/coord)
+
+(s/def ::db (s/keys :req [:map/state                          
                           :animation/percentage
                           :animation/state
                           :ui.collapsible-tabs/tabs
                           :ui.switch-buttons/states
                           :ui/parameters]
                     :opt [:map/data
-                          :analysis/data]))
+                          :analysis/data
+                          :analysis/selected-object-id
+                          :analysis/possible-objects-ids
+                          :map/popup-coord]))
 
 (defn initial-db []
   {:map/state {:scale 1

--- a/src/cljs/analysis_viewer/db.cljs
+++ b/src/cljs/analysis_viewer/db.cljs
@@ -5,9 +5,8 @@
 
 (s/def :map/scale number?)
 (s/def :map/translate :cartesian/coord)
-(s/def :map/screen-origin :cartesian/coord)
 (s/def :map/screen-current :cartesian/coord)
-(s/def :map/grab (s/keys :req-un [:map/screen-origin :map/screen-current]))
+(s/def :map/grab (s/keys :req-un [:map/screen-current]))
 (s/def :map/state (s/keys :req-un [:map/scale
                                    :map/translate]
                           :opt-un [:map/grab]))
@@ -21,7 +20,10 @@
 
 (s/def :ui.collapsible-tabs/tabs (s/map-of keyword? (s/map-of keyword? boolean?)))
 (s/def :ui.switch-buttons/states (s/map-of keyword? boolean?))
-(s/def :ui/parameters map?)
+(s/def :parameter/border-color string?)
+(s/def :parameter/polygon-opacity (s/and number? #(<= 0 % 1)))
+(s/def :ui/parameters (s/keys :req-un [:parameter/map-borders-color
+                                       :parameter/polygon-opacity]))
 
 (s/def ::db (s/keys :req [:map/state
                           :ui.collapsible-tabs/tabs
@@ -37,4 +39,5 @@
                                            :map-color true,
                                            :polygon-opacity true}}
    :ui.switch-buttons/states {:map-borders true}
-   :ui/parameters {:map-borders-color "#079DAB"}})
+   :ui/parameters {:map-borders-color "#079DAB"
+                   :polygon-opacity 0.3}})

--- a/src/cljs/analysis_viewer/db.cljs
+++ b/src/cljs/analysis_viewer/db.cljs
@@ -23,7 +23,10 @@
 (s/def :analysis.data/object any?) ;; TODO: I think this can be specified
 (s/def :analysis.data.object/id string?)
 (s/def :analysis.data/type #{:ContinuousTree :DiscreteTree :BayesFactor})
-(s/def :analysis/data (s/map-of :analysis.data.object/id :analysis.data/object)) 
+(s/def :analysis/data (s/map-of :analysis.data.object/id :analysis.data/object))
+
+(s/def :analysis.linear-attribute/range (s/tuple number? number?))
+(s/def :analysis/linear-attributes (s/map-of string? :analysis.linear-attribute/range))
 
 (s/def :ui.collapsible-tabs/tabs (s/map-of keyword? (s/map-of keyword? boolean?)))
 (s/def :ui.switch-buttons/states (s/map-of keyword? boolean?))
@@ -69,6 +72,7 @@
                     :opt [:map/data
                           :analysis/data
                           :analysis.data/type
+                          :analysis/linear-attributes
                           :analysis/selected-object-id
                           :analysis/possible-objects-ids
                           :map/popup-coord]))

--- a/src/cljs/analysis_viewer/db.cljs
+++ b/src/cljs/analysis_viewer/db.cljs
@@ -1,5 +1,8 @@
 (ns analysis-viewer.db
-  (:require [clojure.spec.alpha :as s]))
+  (:require [clojure.spec.alpha :as s]
+            [clojure.string :as str]))
+
+(s/def :html/color (s/and string? #(str/starts-with? % "#")))
 
 (s/def :cartesian/coord (s/tuple number? number?))
 
@@ -26,6 +29,7 @@
 (s/def :analysis/data (s/map-of :analysis.data.object/id :analysis.data/object))
 
 (s/def :analysis.linear-attribute/range (s/tuple number? number?))
+(s/def :analysis.linear-attribute/color-range (s/tuple :html/color :html/color))
 (s/def :analysis/linear-attributes (s/map-of string? :analysis.linear-attribute/range))
 
 (s/def :ui.collapsible-tabs/tabs (s/map-of keyword? (s/map-of keyword? boolean?)))
@@ -43,6 +47,13 @@
 (s/def :parameter/labels-color string?)
 (s/def :parameter/labels-size number?)
 
+(s/def :parameter/linear-attribute (s/tuple string?
+                                            :analysis.linear-attribute/range
+                                            :analysis.linear-attribute/color-range))
+(s/def :parameter/transitions-attribute :parameter/linear-attribute)
+(s/def :parameter/circles-attribute :parameter/linear-attribute)
+(s/def :parameter/nodes-attribute :parameter/linear-attribute)
+
 (s/def :ui/parameters (s/keys :req-un [:parameter/map-borders-color
                                        :parameter/polygons-color
                                        :parameter/polygons-opacity
@@ -54,7 +65,10 @@
                                        :parameter/nodes-color
                                        :parameter/nodes-size
                                        :parameter/labels-color
-                                       :parameter/labels-size]))
+                                       :parameter/labels-size]
+                              :opt-un [:parameter/transitions-attribute
+                                       :parameter/circles-attribute
+                                       :parameter/nodes-attribute]))
 
 (s/def :animation/percentage (s/and number? #(<= 0 % 1)))
 (s/def :animation/state #{:stop :play})

--- a/src/cljs/analysis_viewer/db.cljs
+++ b/src/cljs/analysis_viewer/db.cljs
@@ -36,5 +36,5 @@
    :ui.collapsible-tabs/tabs {:parameters {:layer-visibility true,
                                            :map-color true,
                                            :polygon-opacity true}}
-   :ui.switch-buttons/states {}
+   :ui.switch-buttons/states {:map-borders true}
    :ui/parameters {:map-borders-color "#079DAB"}})

--- a/src/cljs/analysis_viewer/db.cljs
+++ b/src/cljs/analysis_viewer/db.cljs
@@ -25,7 +25,12 @@
 (s/def :ui/parameters (s/keys :req-un [:parameter/map-borders-color
                                        :parameter/polygon-opacity]))
 
+(s/def :animation/percentage (s/and number? #(<= 0 % 1)))
+(s/def :animation/state #{:stop :play})
+
 (s/def ::db (s/keys :req [:map/state
+                          :animation/percentage
+                          :animation/state
                           :ui.collapsible-tabs/tabs
                           :ui.switch-buttons/states
                           :ui/parameters]
@@ -35,6 +40,8 @@
 (defn initial-db []
   {:map/state {:scale 1
                :translate [0 0]}
+   :animation/percentage 0
+   :animation/state :stop
    :ui.collapsible-tabs/tabs {:parameters {:layer-visibility true,
                                            :map-color true,
                                            :polygon-opacity true}}

--- a/src/cljs/analysis_viewer/db.cljs
+++ b/src/cljs/analysis_viewer/db.cljs
@@ -22,14 +22,36 @@
 (s/def :maps/data (s/coll-of :map/data))
 (s/def :analysis.data/object any?) ;; TODO: I think this can be specified
 (s/def :analysis.data.object/id string?)
+(s/def :analysis.data/type #{:ContinuousTree :DiscreteTree :BayesFactor})
 (s/def :analysis/data (s/map-of :analysis.data.object/id :analysis.data/object)) 
 
 (s/def :ui.collapsible-tabs/tabs (s/map-of keyword? (s/map-of keyword? boolean?)))
 (s/def :ui.switch-buttons/states (s/map-of keyword? boolean?))
 (s/def :parameter/border-color string?)
-(s/def :parameter/polygon-opacity (s/and number? #(<= 0 % 1)))
+(s/def :parameter/polygons-opacity (s/and number? #(<= 0 % 1)))
+(s/def :parameter/polygons-color string?)
+(s/def :parameter/transitions-opacity (s/and number? #(<= 0 % 1)))
+(s/def :parameter/transitions-curvature (s/and number? #(<= 0 % 2)))
+(s/def :parameter/transitions-width (s/and number? #(<= 0 % 0.3)))
+(s/def :parameter/circles-raduis number?)
+(s/def :parameter/cirlces-color string?)
+(s/def :parameter/nodes-color string?)
+(s/def :parameter/nodes-size number?)
+(s/def :parameter/labels-color string?)
+(s/def :parameter/labels-size number?)
+
 (s/def :ui/parameters (s/keys :req-un [:parameter/map-borders-color
-                                       :parameter/polygon-opacity]))
+                                       :parameter/polygons-color
+                                       :parameter/polygons-opacity
+                                       :parameter/transitions-color
+                                       :parameter/transitions-curvature
+                                       :parameter/transitions-width
+                                       :parameter/circles-radius
+                                       :parameter/circles-color
+                                       :parameter/nodes-color
+                                       :parameter/nodes-size
+                                       :parameter/labels-color
+                                       :parameter/labels-size]))
 
 (s/def :animation/percentage (s/and number? #(<= 0 % 1)))
 (s/def :animation/state #{:stop :play})
@@ -46,6 +68,7 @@
                           :ui/parameters]
                     :opt [:map/data
                           :analysis/data
+                          :analysis.data/type
                           :analysis/selected-object-id
                           :analysis/possible-objects-ids
                           :map/popup-coord]))
@@ -60,6 +83,22 @@
    :ui.collapsible-tabs/tabs {:parameters {:layer-visibility true,
                                            :map-color true,
                                            :polygon-opacity true}}
-   :ui.switch-buttons/states {:map-borders true}
+   :ui.switch-buttons/states {:show-map? true
+                              :map-borders? true
+                              :map-labels? true
+                              :transitions? true
+                              :circles? true
+                              :nodes? true
+                              :labels? true}
    :ui/parameters {:map-borders-color "#079DAB"
-                   :polygon-opacity 0.3}})
+                   :polygons-color "#1C58D0"
+                   :polygons-opacity 0.3
+                   :transitions-color "#266C08"
+                   :transitions-curvature 1
+                   :transitions-width 0.1
+                   :circles-radius 1
+                   :circles-color "#EEBE53"
+                   :nodes-color "#B20707"
+                   :nodes-size 0.1
+                   :labels-color "#ECEFF8"
+                   :labels-size 0.5}})

--- a/src/cljs/analysis_viewer/db.cljs
+++ b/src/cljs/analysis_viewer/db.cljs
@@ -19,11 +19,13 @@
 (s/def :maps/data (s/coll-of :map/data))
 (s/def :analysis/data any?) ;; TODO: I think this can be specified
 
-(s/def :ui.collapsible-tabs/tabs (s/nilable (s/map-of keyword? (s/map-of keyword? boolean?))))
+(s/def :ui.collapsible-tabs/tabs (s/map-of keyword? (s/map-of keyword? boolean?)))
+(s/def :ui.switch-buttons/states (s/map-of keyword? boolean?))
 (s/def :ui/parameters map?)
 
 (s/def ::db (s/keys :req [:map/state
                           :ui.collapsible-tabs/tabs
+                          :ui.switch-buttons/states
                           :ui/parameters]
                     :opt [:map/data
                           :analysis/data]))
@@ -31,5 +33,8 @@
 (defn initial-db []
   {:map/state {:scale 1
                :translate [0 0]}
-   :ui.collapsible-tabs/tabs {}
+   :ui.collapsible-tabs/tabs {:parameters {:layer-visibility true,
+                                           :map-color true,
+                                           :polygon-opacity true}}
+   :ui.switch-buttons/states {}
    :ui/parameters {:map-borders-color "#079DAB"}})

--- a/src/cljs/analysis_viewer/events.cljs
+++ b/src/cljs/analysis_viewer/events.cljs
@@ -24,6 +24,7 @@
 
 ;; map graphics manipulation
 (reg-event-db :map/set-view-box [sc] events.maps/set-view-box)
+(reg-event-db :map/zoom-inc events.maps/zoom-inc)
 (reg-event-db :map/zoom events.maps/zoom)
 (reg-event-db :map/grab [sc] events.maps/map-grab)
 (reg-event-db :map/grab-release [sc] events.maps/map-release)

--- a/src/cljs/analysis_viewer/events.cljs
+++ b/src/cljs/analysis_viewer/events.cljs
@@ -34,6 +34,11 @@
 (reg-event-fx :map/zoom-rectangle-release [sc] events.maps/zoom-rectangle-release)
 (reg-event-fx :map/toggle-show-world [sc] events.maps/toggle-show-world)
 
+(reg-event-db :map/show-object-attributes [sc] events.maps/show-object-attributes)
+(reg-event-db :map/hide-object-attributes [sc] events.maps/hide-object-attributes)
+(reg-event-db :map/show-object-selector [sc] events.maps/show-object-selector)
+(reg-event-db :map/hide-object-selector [sc] events.maps/hide-object-selector)
+
 (reg-event-db :collapsible-tabs/toggle [sc] events.ui/toggle-collapsible-tab)
 (reg-event-db :switch-button/toggle [sc] events.ui/toggle-switch-button)
 (reg-event-db :parameters/select [sc] events.ui/parameters-select)

--- a/src/cljs/analysis_viewer/events.cljs
+++ b/src/cljs/analysis_viewer/events.cljs
@@ -34,4 +34,5 @@
 (reg-event-fx :map/toggle-show-world [sc] events.maps/toggle-show-world)
 
 (reg-event-db :collapsible-tabs/toggle [sc] events.ui/toggle-collapsible-tab)
+(reg-event-db :switch-button/toggle [sc] events.ui/toggle-switch-button)
 (reg-event-db :parameters/select [sc] events.ui/parameters-select)

--- a/src/cljs/analysis_viewer/events.cljs
+++ b/src/cljs/analysis_viewer/events.cljs
@@ -37,3 +37,9 @@
 (reg-event-db :collapsible-tabs/toggle [sc] events.ui/toggle-collapsible-tab)
 (reg-event-db :switch-button/toggle [sc] events.ui/toggle-switch-button)
 (reg-event-db :parameters/select [sc] events.ui/parameters-select)
+
+(reg-event-db :animation/prev [sc] events.maps/animation-prev)
+(reg-event-db :animation/next [sc] events.maps/animation-next)
+(reg-event-fx :animation/toggle-play-stop [sc] events.maps/animation-toggle-play-stop)
+
+(reg-event-fx :ticker/tick [] events.maps/ticker-tick)

--- a/src/cljs/analysis_viewer/events.cljs
+++ b/src/cljs/analysis_viewer/events.cljs
@@ -34,3 +34,4 @@
 (reg-event-fx :map/toggle-show-world [sc] events.maps/toggle-show-world)
 
 (reg-event-db :collapsible-tabs/toggle [sc] events.ui/toggle-collapsible-tab)
+(reg-event-db :parameters/select [sc] events.ui/parameters-select)

--- a/src/cljs/analysis_viewer/events.cljs
+++ b/src/cljs/analysis_viewer/events.cljs
@@ -43,3 +43,5 @@
 (reg-event-fx :animation/toggle-play-stop [sc] events.maps/animation-toggle-play-stop)
 
 (reg-event-fx :ticker/tick [] events.maps/ticker-tick)
+
+(reg-event-db :map/set-dimensions [sc] events.maps/set-dimensions)

--- a/src/cljs/analysis_viewer/events/maps.cljs
+++ b/src/cljs/analysis_viewer/events/maps.cljs
@@ -173,10 +173,9 @@
                                         :analysis-data (:analysis/data db)
                                         :time (:animation/percentage db)}})
 
-(def tick-step 0.02)
-
+(def tick-step 0.000750188)
 (defn ticker-tick [{:keys [db]} _]
-  (let [{:keys [animation/percentage]} db]
+  (let [{:keys [animation/percentage]} db]    
     (if (>= (+ percentage tick-step) 1)
       {:db (assoc db :animation/percentage 1)
        :ticker/stop nil}
@@ -205,3 +204,4 @@
   (-> db
       (assoc-in [:map/state :width] width)
       (assoc-in [:map/state :height] height)))
+ 

--- a/src/cljs/analysis_viewer/events/maps.cljs
+++ b/src/cljs/analysis_viewer/events/maps.cljs
@@ -55,7 +55,7 @@
                         :ContinuousTree (map-emitter/continuous-tree-output->map-data data)
                         :DiscreteTree   (map-emitter/discrete-tree-output->map-data data)
                         :BayesFactor    (map-emitter/bayes-output->map-data data))
-        {:keys [x1 y1 x2 y2]} (get-analysis-objects-view-box analysis-data)
+        {:keys [x1 y1 x2 y2]} (get-analysis-objects-view-box (vals analysis-data))
         padding 2]
 
     {:db (-> db
@@ -204,3 +204,19 @@
       (assoc-in [:map/state :width] width)
       (assoc-in [:map/state :height] height)))
  
+
+(defn show-object-attributes [db [_ object-id coord]]
+  (assoc db
+         :analysis/selected-object-id object-id
+         :map/popup-coord coord))
+
+(defn hide-object-attributes [db _]
+  (dissoc db :analysis/selected-object-id :map/popup-coord))
+
+(defn show-object-selector [db [_ objects-ids coord]]
+  (assoc db
+         :analysis/possible-objects-ids (into [] objects-ids)
+         :map/popup-coord coord))
+
+(defn hide-object-selector [db _]
+  (dissoc db :analysis/possible-objects-ids :map/popup-coord))

--- a/src/cljs/analysis_viewer/events/maps.cljs
+++ b/src/cljs/analysis_viewer/events/maps.cljs
@@ -56,7 +56,7 @@
                         :DiscreteTree   (map-emitter/discrete-tree-output->map-data data)
                         :BayesFactor    (map-emitter/bayes-output->map-data data)
                         :TimeSlicer     (map-emitter/timeslicer-output->map-data data))
-        {:keys [x1 y1 x2 y2] :as vb} (get-analysis-objects-view-box analysis-data)
+        {:keys [x1 y1 x2 y2]} (get-analysis-objects-view-box analysis-data)
         padding 2]
 
     {:db (-> db
@@ -84,7 +84,7 @@
   ;; TODO: this is correct on wide windows, make it work
   ;; on windows that are higher than wider
   
-  (let [{:keys [width height]} state
+  (let [{:keys [height]} state
         width (* 2 height)]
     (/ width map-proj-width)))
 
@@ -119,7 +119,7 @@
                   map-state))))))
 
 (defn zoom-inc [{:keys [map/state] :as db} [_ {:keys [delta x y]}]]
-  (let [{:keys [translate scale]} state
+  (let [{:keys [scale]} state
         zoom-dir (if (pos? delta) -1 1)
         new-scale (+ scale (* zoom-dir 0.8))]
     (zoom db [nil x y new-scale])))

--- a/src/cljs/analysis_viewer/events/maps.cljs
+++ b/src/cljs/analysis_viewer/events/maps.cljs
@@ -173,10 +173,14 @@
 (defn toggle-show-world [{:keys [db]} _]
   {:db (update-in db [:map/state :show-world?] not)})
 
-(defn download-current-as-svg [{:keys [db]} [_ ]]
-  {:spread/download-current-map-as-svg {:geo-json-map (subs/geo-json-data-map (:maps/data db))
-                                        :analysis-data (:analysis/data db)
-                                        :time (:animation/percentage db)}})
+(defn download-current-as-svg [{:keys [db]} [_ ]]  
+  (let [ui-params (:ui/parameters db)
+        map-params (subs/build-map-parameters (:ui/parameters db) (:switch-buttons/states db))]
+    {:spread/download-current-map-as-svg {:geo-json-map (subs/geo-json-data-map (:maps/data db))
+                                          :analysis-data (:analysis/data db)
+                                          :time (:animation/percentage db)
+                                          :ui-params ui-params
+                                          :map-params map-params}}))
 
 (def tick-step 0.000750188)
 (defn ticker-tick [{:keys [db]} _]

--- a/src/cljs/analysis_viewer/events/maps.cljs
+++ b/src/cljs/analysis_viewer/events/maps.cljs
@@ -60,7 +60,12 @@
 
     {:db (-> db
              (assoc :analysis/data analysis-data)
-             (assoc :analysis.data/type analysis-type))
+             (assoc :analysis.data/type analysis-type)
+             (assoc :analysis/linear-attributes (->> (:pointAttributes data)
+                                                     (keep (fn [{:keys [id scale range]}]
+                                                             (when (= scale "linear")
+                                                               [id range])))
+                                                     (into {}))))
      :dispatch [:map/set-view-box {:x1 (- x1 padding) :y1 (- y1 padding)
                                    :x2 (+ x2 padding) :y2 (+ y2 padding)}]}))
 

--- a/src/cljs/analysis_viewer/events/maps.cljs
+++ b/src/cljs/analysis_viewer/events/maps.cljs
@@ -11,6 +11,8 @@
 ;; proj-coord:   [x,y]      coordinates in map projection coords, 0 <= x <= 360, 0 <= y <= 180
 ;; map-coord:    [lat,lon]  coordinates in map lat,long coords, -180 <= lon <= 180, -90 <= lat <= 90
 
+;; TODO: this should be obtained after the map svg is rendered
+;; since the map screen size isn't fixed anymore
 (def map-screen-width    1200)
 (def map-screen-height   600)
 
@@ -20,7 +22,7 @@
 (def proj-scale (/ map-screen-width map-proj-width))
 
 (def max-scale 22)
-(def min-scale 0.1)
+(def min-scale 0.8)
 
 ;; TODO: grab this from config
 (def s3-bucket-url "http://127.0.0.1:9000/spread-dev-uploads/")

--- a/src/cljs/analysis_viewer/events/maps.cljs
+++ b/src/cljs/analysis_viewer/events/maps.cljs
@@ -54,8 +54,7 @@
         analysis-data (case analysis-type
                         :ContinuousTree (map-emitter/continuous-tree-output->map-data data)
                         :DiscreteTree   (map-emitter/discrete-tree-output->map-data data)
-                        :BayesFactor    (map-emitter/bayes-output->map-data data)
-                        :TimeSlicer     (map-emitter/timeslicer-output->map-data data))
+                        :BayesFactor    (map-emitter/bayes-output->map-data data))
         {:keys [x1 y1 x2 y2]} (get-analysis-objects-view-box analysis-data)
         padding 2]
 

--- a/src/cljs/analysis_viewer/events/maps.cljs
+++ b/src/cljs/analysis_viewer/events/maps.cljs
@@ -42,7 +42,7 @@
                                   (case (:type o)
                                     :arc [(:from-coord o) (:to-coord o)]
                                     :point [(:coord o)]
-                                    :area (:coord o)))))]
+                                    :area (:coords o)))))]
     {:x1 (apply min (map first all-coords))
      :y1 (apply min (map second all-coords))
      :x2 (apply max (map first all-coords))
@@ -54,7 +54,7 @@
                         :discrete-tree   (map-emitter/discrete-tree-output->map-data data)
                         :bayes           (map-emitter/bayes-output->map-data data)
                         :timeslicer      (map-emitter/timeslicer-output->map-data data))
-        {:keys [x1 y1 x2 y2]} (get-analysis-objects-view-box analysis-data)
+        {:keys [x1 y1 x2 y2] :as vb} (get-analysis-objects-view-box analysis-data)
         padding 2]
 
     {:db (-> db

--- a/src/cljs/analysis_viewer/events/maps.cljs
+++ b/src/cljs/analysis_viewer/events/maps.cljs
@@ -59,7 +59,8 @@
         padding 2]
 
     {:db (-> db
-             (assoc :analysis/data analysis-data))
+             (assoc :analysis/data analysis-data)
+             (assoc :analysis.data/type analysis-type))
      :dispatch [:map/set-view-box {:x1 (- x1 padding) :y1 (- y1 padding)
                                    :x2 (+ x2 padding) :y2 (+ y2 padding)}]}))
 

--- a/src/cljs/analysis_viewer/events/maps.cljs
+++ b/src/cljs/analysis_viewer/events/maps.cljs
@@ -50,7 +50,10 @@
 
 (defn data-loaded [{:keys [db]} [_ analysis-type data]]
   (let [analysis-data (case analysis-type
-                        :continuous-tree (map-emitter/continuous-tree-output->map-data data))
+                        :continuous-tree (map-emitter/continuous-tree-output->map-data data)
+                        :discrete-tree   (map-emitter/discrete-tree-output->map-data data)
+                        :bayes           (map-emitter/bayes-output->map-data data)
+                        :timeslicer      (map-emitter/timeslicer-output->map-data data))
         {:keys [x1 y1 x2 y2]} (get-analysis-objects-view-box analysis-data)
         padding 2]
 

--- a/src/cljs/analysis_viewer/events/maps.cljs
+++ b/src/cljs/analysis_viewer/events/maps.cljs
@@ -88,15 +88,13 @@
         (assoc :map/state {:translate translate
                            :scale     scale}))))
 
-(defn zoom [{:keys [map/state] :as db} [_ {:keys [delta x y]}]]
-  (let [screen-coords [x y]
-        {:keys [translate scale]} state
-        zoom-dir (if (pos? delta) -1 1)
+(defn zoom [{:keys [map/state] :as db} [_ x y new-scale]]
+  (let [{:keys [translate scale]} state
+        screen-coords [x y]
         [proj-x proj-y] (math-utils/screen-coord->proj-coord translate scale proj-scale screen-coords)]
     (update db :map/state
             (fn [{:keys [translate scale] :as map-state}]
-              (let [new-scale (+ scale (* zoom-dir 0.8))
-                    scaled-proj-x (* proj-x scale proj-scale)
+              (let [scaled-proj-x (* proj-x scale proj-scale)
                     scaled-proj-y (* proj-y scale proj-scale)
                     new-scaled-proj-x (* proj-x new-scale proj-scale)
                     new-scaled-proj-y (* proj-y new-scale proj-scale)
@@ -112,9 +110,14 @@
                          :scale new-scale)
                   map-state))))))
 
+(defn zoom-inc [{:keys [map/state] :as db} [_ {:keys [delta x y]}]]
+  (let [{:keys [translate scale]} state
+        zoom-dir (if (pos? delta) -1 1)
+        new-scale (+ scale (* zoom-dir 0.8))]
+    (zoom db [nil x y new-scale])))
+
 (defn map-grab [db [_ {:keys [x y]}]]
   (-> db
-      (assoc-in [:map/state :grab :screen-origin]  [x y])
       (assoc-in [:map/state :grab :screen-current]  [x y])))
 
 (defn map-release [db _]

--- a/src/cljs/analysis_viewer/events/ui.cljs
+++ b/src/cljs/analysis_viewer/events/ui.cljs
@@ -3,6 +3,9 @@
 (defn toggle-collapsible-tab [db [_ parent-id tab-id]]
   (update-in db [:ui.collapsible-tabs/tabs parent-id tab-id] not))
 
+(defn toggle-switch-button [db [_ button-id]]
+  (update-in db [:ui.switch-buttons/states button-id] not))
+
 (defn parameters-select [db [_ param-id value]]
   (assoc-in db [:ui/parameters param-id] value))
 

--- a/src/cljs/analysis_viewer/events/ui.cljs
+++ b/src/cljs/analysis_viewer/events/ui.cljs
@@ -1,6 +1,8 @@
 (ns analysis-viewer.events.ui)
 
 (defn toggle-collapsible-tab [db [_ parent-id tab-id]]
-  (update-in db [:ui.collapsible-tabs/tabs parent-id tab-id] not)
-  )
+  (update-in db [:ui.collapsible-tabs/tabs parent-id tab-id] not))
+
+(defn parameters-select [db [_ param-id value]]
+  (assoc-in db [:ui/parameters param-id] value))
 

--- a/src/cljs/analysis_viewer/fxs.cljs
+++ b/src/cljs/analysis_viewer/fxs.cljs
@@ -5,7 +5,7 @@
             [hiccups.runtime :as hiccupsrt]
             [re-frame.core :as re-frame]))
 
-(defn data-map [geo-json-map analysis-data time]
+(defn data-map [geo-json-map analysis-data time opts]
   [:svg {:xmlns "http://www.w3.org/2000/svg"
          :xmlns:amcharts "http://amcharts.com/ammap"
          :xmlns:xlink "http://www.w3.org/1999/xlink"
@@ -21,15 +21,14 @@
      [:stop {:offset "100%" :stop-color :yellow}]]]
 
    ;; map background
-   [:rect {:x "0" :y "0" :width "100%" :height "100%" :fill (:background-color views/theme)}]
+   [:rect {:x "0" :y "0" :width "100%" :height "100%" :fill (:background-color opts)}]
    
    ;; map and data svg
    [:g {}
     [:svg {:view-box "0 0 360 180"}
      ;; map group
      [:g {}
-      (binding [svg-renderer/*theme* views/theme]
-        (svg-renderer/geojson->svg geo-json-map))]
+      (svg-renderer/geojson->svg geo-json-map opts)]
 
      ;; data group
      [:g {}
@@ -41,8 +40,9 @@
 
 (re-frame/reg-fx
  :spread/download-current-map-as-svg
- (fn [{:keys [geo-json-map analysis-data time]}]
-   (let [ svg-text (html (data-map geo-json-map analysis-data time))
+ (fn [{:keys [geo-json-map analysis-data time opts]}]
+   (let [map-options @(re-frame/subscribe [:map/parameters])
+         svg-text (html (data-map geo-json-map analysis-data time map-options))
          download-anchor (js/document.createElement "a")]
 
      (.setAttribute download-anchor "href" (str "data:image/svg+xml;charset=utf-8," (js/encodeURIComponent svg-text)))

--- a/src/cljs/analysis_viewer/fxs.cljs
+++ b/src/cljs/analysis_viewer/fxs.cljs
@@ -5,7 +5,7 @@
             [hiccups.runtime :as hiccupsrt]
             [re-frame.core :as re-frame]))
 
-(defn data-map [geo-json-map analysis-data time opts]
+(defn data-map [geo-json-map analysis-data time map-opts ui-params]
   [:svg {:xmlns "http://www.w3.org/2000/svg"
          :xmlns:amcharts "http://amcharts.com/ammap"
          :xmlns:xlink "http://www.w3.org/1999/xlink"
@@ -21,14 +21,14 @@
      [:stop {:offset "100%" :stop-color :yellow}]]]
 
    ;; map background
-   [:rect {:x "0" :y "0" :width "100%" :height "100%" :fill (:background-color opts)}]
+   [:rect {:x "0" :y "0" :width "100%" :height "100%" :fill (:background-color map-opts)}]
    
    ;; map and data svg
    [:g {}
     [:svg {:view-box "0 0 360 180"}
      ;; map group
      [:g {}
-      (svg-renderer/geojson->svg geo-json-map opts)]
+      (svg-renderer/geojson->svg geo-json-map map-opts)]
 
      ;; data group
      [:g {}
@@ -36,13 +36,14 @@
         [:g {}
          (for [primitive-object analysis-data]
            ^{:key (str (:id primitive-object))}
-           (views/map-primitive-object primitive-object 1 time))])]]]])
+           (views/map-primitive-object primitive-object 1 time ui-params))])]]]])
 
 (re-frame/reg-fx
  :spread/download-current-map-as-svg
  (fn [{:keys [geo-json-map analysis-data time opts]}]
-   (let [map-options @(re-frame/subscribe [:map/parameters])
-         svg-text (html (data-map geo-json-map analysis-data time map-options))
+   (let [params @(re-frame/subscribe [:ui/parameters])
+         map-options @(re-frame/subscribe [:map/parameters])
+         svg-text (html (data-map geo-json-map analysis-data time map-options params))
          download-anchor (js/document.createElement "a")]
 
      (.setAttribute download-anchor "href" (str "data:image/svg+xml;charset=utf-8," (js/encodeURIComponent svg-text)))

--- a/src/cljs/analysis_viewer/fxs.cljs
+++ b/src/cljs/analysis_viewer/fxs.cljs
@@ -40,7 +40,7 @@
 
 (re-frame/reg-fx
  :spread/download-current-map-as-svg
- (fn [{:keys [geo-json-map analysis-data time opts]}]
+ (fn [{:keys [geo-json-map analysis-data time]}]
    (let [params @(re-frame/subscribe [:ui/parameters])
          map-options @(re-frame/subscribe [:map/parameters])
          svg-text (html (data-map geo-json-map analysis-data time map-options params))

--- a/src/cljs/analysis_viewer/fxs.cljs
+++ b/src/cljs/analysis_viewer/fxs.cljs
@@ -52,3 +52,25 @@
      (js/document.body.appendChild download-anchor)
      (.click download-anchor)
      (js/document.body.removeChild download-anchor))))
+
+(def ticker-ref (atom nil))
+
+(defn stop-ticker []
+  (when-let [ticker @ticker-ref]    
+    (js/clearInterval ticker)))
+
+(re-frame/reg-fx
+ :ticker/start
+ (fn [{:keys [millis]}]
+   ;; make sure no ticker is running before starting one
+   (stop-ticker)
+   
+   (reset! ticker-ref
+           (js/setInterval (fn []
+                             (re-frame/dispatch [:ticker/tick]))
+                           millis))))
+
+(re-frame/reg-fx
+ :ticker/stop
+ (fn [_]
+   (stop-ticker)))

--- a/src/cljs/analysis_viewer/fxs.cljs
+++ b/src/cljs/analysis_viewer/fxs.cljs
@@ -3,7 +3,8 @@
   (:require [analysis-viewer.svg-renderer :as svg-renderer]
             [analysis-viewer.views :as views]
             [hiccups.runtime :as hiccupsrt]
-            [re-frame.core :as re-frame]))
+            [re-frame.core :as re-frame]
+            [shared.math-utils :as math-utils]))
 
 (defn data-map [geo-json-map analysis-data time map-opts ui-params]
   [:svg {:xmlns "http://www.w3.org/2000/svg"
@@ -27,8 +28,10 @@
    [:g {}
     [:svg {:view-box "0 0 360 180"}
      ;; map group
-     [:g {}
-      (svg-renderer/geojson->svg geo-json-map map-opts)]
+     [:g {}      
+      (binding [svg-renderer/*coord-transform-fn* math-utils/map-coord->proj-coord]
+        (svg-renderer/geojson->svg geo-json-map 
+                                  map-opts))]
 
      ;; data group
      [:g {}

--- a/src/cljs/analysis_viewer/fxs.cljs
+++ b/src/cljs/analysis_viewer/fxs.cljs
@@ -43,10 +43,8 @@
 
 (re-frame/reg-fx
  :spread/download-current-map-as-svg
- (fn [{:keys [geo-json-map analysis-data time]}]
-   (let [params @(re-frame/subscribe [:ui/parameters])
-         map-options @(re-frame/subscribe [:map/parameters])
-         svg-text (html (data-map geo-json-map analysis-data time map-options params))
+ (fn [{:keys [geo-json-map analysis-data time map-params ui-params]}]
+   (let [svg-text (html (data-map geo-json-map analysis-data time map-params ui-params))
          download-anchor (js/document.createElement "a")]
 
      (.setAttribute download-anchor "href" (str "data:image/svg+xml;charset=utf-8," (js/encodeURIComponent svg-text)))

--- a/src/cljs/analysis_viewer/main.cljs
+++ b/src/cljs/analysis_viewer/main.cljs
@@ -19,6 +19,7 @@
 ;; [B]  http://localhost:8021/?output=a1195874-0bbe-4a8c-96f5-14cdf9097e02/ba47f735-0a97-40b1-b761-860b1a914e28.json
 ;; [TS] http://localhost:8021/?output=a1195874-0bbe-4a8c-96f5-14cdf9097e02/8d7b6ea9-b4f7-4387-9b35-042e5ed89981.json
 
+;; [DT] http://localhost:8021/?output=a1195874-0bbe-4a8c-96f5-14cdf9097e02/893367d9-7224-4587-b492-8344e45e6e83.json&maps=
 (defn parse-url-qstring [qstring]
   (->> (str/split qstring #"&")
        (map (fn [s]
@@ -37,7 +38,7 @@
   (let [{:keys [maps output]} (parse-url-qstring (subs js/window.location.search 1))]
     (re-frame/dispatch-sync [:map/initialize
                              (into ["WORLD"] (remove str/blank? (str/split maps #",")) )                             
-                             (str events.maps/s3-bucket-url "/" output)])
+                             (str events.maps/s3-bucket-url output)])
     (rdom/render [views/main-screen]
                  (.getElementById js/document "app"))))
 

--- a/src/cljs/analysis_viewer/main.cljs
+++ b/src/cljs/analysis_viewer/main.cljs
@@ -8,8 +8,7 @@
             [flow-storm.api :as fsa]
             [re-frame.core :as re-frame]
             [re-frame.db]
-            [reagent.dom :as rdom]
-            [clojure.string :as str]))
+            [reagent.dom :as rdom]))
 
 (defn ^:dev/before-load stop []
   (js/console.log "Stopping..."))

--- a/src/cljs/analysis_viewer/main.cljs
+++ b/src/cljs/analysis_viewer/main.cljs
@@ -15,11 +15,23 @@
 
 ;; google-chrome --allow-file-access-from-files file:///home/jmonetta/non-rep-software/spread-d3/language_D3/renderers/d3/d3renderer/index.html
 
+;; Some continuous tree examples
 
-;; http://localhost:8021/?output=a1195874-0bbe-4a8c-96f5-14cdf9097e02/644e6959-0a6c-4da8-8413-cb4caafe5f62.json&maps=AU,TZ
+;; http://localhost:8021/?output-type=continuous-tree&output=a1195874-0bbe-4a8c-96f5-14cdf9097e02/644e6959-0a6c-4da8-8413-cb4caafe5f62.json&maps=AU,TZ
+;; http://localhost:8021/?maps=AU,TZ&output-type=continuous-tree&output=a1195874-0bbe-4a8c-96f5-14cdf9097e02/3a6cc419-5da4-4d28-8b0d-f74c98a89d6e.json
+;; http://localhost:8021/?output-type=continuous-tree&output=a1195874-0bbe-4a8c-96f5-14cdf9097e02/3a6cc419-5da4-4d28-8b0d-f74c98a89d6e.json&maps=AU,TZ
 
-;; http://localhost:8021/?maps=AU,TZ&output=a1195874-0bbe-4a8c-96f5-14cdf9097e02/3a6cc419-5da4-4d28-8b0d-f74c98a89d6e.json
-;; http://localhost:8021/?output=a1195874-0bbe-4a8c-96f5-14cdf9097e02/3a6cc419-5da4-4d28-8b0d-f74c98a89d6e.json&maps=AU,TZ
+;; Some discrete tree examples
+
+;; http://localhost:8021/?output-type=discrete-tree&output=a1195874-0bbe-4a8c-96f5-14cdf9097e02/985ecd9f-a9eb-425d-9795-7e92a81d2941.json&maps=AU,TZ
+
+;; Some bayes examples
+
+;; http://localhost:8021/?output-type=bayes&output=a1195874-0bbe-4a8c-96f5-14cdf9097e02/e9d1f428-0d26-42a0-bb7a-b9c14e59d9dd.json&maps=AU,TZ
+
+;; Some timeslicer examples
+
+;; http://localhost:8021/?output-type=timeslicer&output=a1195874-0bbe-4a8c-96f5-14cdf9097e02/8d76e55a-441b-4e65-8691-7e664b70e5bf.json&maps=AU,TZ
 
 (defn parse-url-qstring [qstring]
   (->> (str/split qstring #"&")
@@ -36,10 +48,10 @@
                                                    :map/state ;; this one changes a lot when zooming, dragging, etc
                                                    :animation/percentage ;; this one changes a lot
                                                    ]}) 
-  (let [{:keys [maps output]} (parse-url-qstring (subs js/window.location.search 1))]
+  (let [{:keys [maps output output-type]} (parse-url-qstring (subs js/window.location.search 1))]
     (re-frame/dispatch-sync [:map/initialize
                              (into ["WORLD"] (str/split maps #",") )
-                             :continuous-tree
+                             (keyword output-type)
                              (str events.maps/s3-bucket-url "/" output)])
     (rdom/render [views/main-screen]
                  (.getElementById js/document "app"))))

--- a/src/cljs/analysis_viewer/main.cljs
+++ b/src/cljs/analysis_viewer/main.cljs
@@ -14,6 +14,10 @@
   (js/console.log "Stopping..."))
 
 ;; google-chrome --allow-file-access-from-files file:///home/jmonetta/non-rep-software/spread-d3/language_D3/renderers/d3/d3renderer/index.html
+
+
+;; http://localhost:8021/?output=a1195874-0bbe-4a8c-96f5-14cdf9097e02/644e6959-0a6c-4da8-8413-cb4caafe5f62.json&maps=AU,TZ
+
 ;; http://localhost:8021/?maps=AU,TZ&output=a1195874-0bbe-4a8c-96f5-14cdf9097e02/3a6cc419-5da4-4d28-8b0d-f74c98a89d6e.json
 ;; http://localhost:8021/?output=a1195874-0bbe-4a8c-96f5-14cdf9097e02/3a6cc419-5da4-4d28-8b0d-f74c98a89d6e.json&maps=AU,TZ
 

--- a/src/cljs/analysis_viewer/main.cljs
+++ b/src/cljs/analysis_viewer/main.cljs
@@ -33,7 +33,7 @@
   (fsa/connect {:tap-name "analysis-viewer"})
   (fsa/trace-ref re-frame.db/app-db {:ref-name "re-frame-db"
                                      :ignore-keys [:maps/data ;; this one is super big
-                                                   :map/state]}) ;; this one changes a lot when zooming, dragging, etc
+                                                   #_:map/state]}) ;; this one changes a lot when zooming, dragging, etc
   (let [{:keys [maps output]} (parse-url-qstring (subs js/window.location.search 1))]
     (re-frame/dispatch-sync [:map/initialize
                              (into ["WORLD"] (str/split maps #",") )

--- a/src/cljs/analysis_viewer/main.cljs
+++ b/src/cljs/analysis_viewer/main.cljs
@@ -8,30 +8,17 @@
             [flow-storm.api :as fsa]
             [re-frame.core :as re-frame]
             [re-frame.db]
-            [reagent.dom :as rdom]))
+            [reagent.dom :as rdom]
+            [clojure.string :as str]))
 
 (defn ^:dev/before-load stop []
   (js/console.log "Stopping..."))
 
 ;; google-chrome --allow-file-access-from-files file:///home/jmonetta/non-rep-software/spread-d3/language_D3/renderers/d3/d3renderer/index.html
 
-;; Some continuous tree examples
-
-;; http://localhost:8021/?output-type=continuous-tree&output=a1195874-0bbe-4a8c-96f5-14cdf9097e02/644e6959-0a6c-4da8-8413-cb4caafe5f62.json&maps=AU,TZ
-;; http://localhost:8021/?maps=AU,TZ&output-type=continuous-tree&output=a1195874-0bbe-4a8c-96f5-14cdf9097e02/3a6cc419-5da4-4d28-8b0d-f74c98a89d6e.json
-;; http://localhost:8021/?output-type=continuous-tree&output=a1195874-0bbe-4a8c-96f5-14cdf9097e02/3a6cc419-5da4-4d28-8b0d-f74c98a89d6e.json&maps=AU,TZ
-
-;; Some discrete tree examples
-
-;; http://localhost:8021/?output-type=discrete-tree&output=a1195874-0bbe-4a8c-96f5-14cdf9097e02/985ecd9f-a9eb-425d-9795-7e92a81d2941.json&maps=CN
-
-;; Some bayes examples
-
-;; http://localhost:8021/?output-type=bayes&output=a1195874-0bbe-4a8c-96f5-14cdf9097e02/e9d1f428-0d26-42a0-bb7a-b9c14e59d9dd.json&maps=CN
-
-;; Some timeslicer examples
-
-;; http://localhost:8021/?output-type=timeslicer&output=a1195874-0bbe-4a8c-96f5-14cdf9097e02/8d76e55a-441b-4e65-8691-7e664b70e5bf.json&maps=AU,TZ
+;; [CT] http://localhost:8021/?output=a1195874-0bbe-4a8c-96f5-14cdf9097e02/dab13811-8c99-454b-9fc4-b31d6dfcae9e.json&maps=
+;; [B]  http://localhost:8021/?output=a1195874-0bbe-4a8c-96f5-14cdf9097e02/ba47f735-0a97-40b1-b761-860b1a914e28.json
+;; [TS] http://localhost:8021/?output=a1195874-0bbe-4a8c-96f5-14cdf9097e02/8d7b6ea9-b4f7-4387-9b35-042e5ed89981.json
 
 (defn parse-url-qstring [qstring]
   (->> (str/split qstring #"&")
@@ -48,10 +35,9 @@
                                                    :map/state ;; this one changes a lot when zooming, dragging, etc
                                                    :animation/percentage ;; this one changes a lot
                                                    ]}) 
-  (let [{:keys [maps output output-type]} (parse-url-qstring (subs js/window.location.search 1))]
+  (let [{:keys [maps output]} (parse-url-qstring (subs js/window.location.search 1))]
     (re-frame/dispatch-sync [:map/initialize
-                             (into ["WORLD"] (str/split maps #",") )
-                             (keyword output-type)
+                             (into ["WORLD"] (remove str/blank? (str/split maps #",")) )                             
                              (str events.maps/s3-bucket-url "/" output)])
     (rdom/render [views/main-screen]
                  (.getElementById js/document "app"))))

--- a/src/cljs/analysis_viewer/main.cljs
+++ b/src/cljs/analysis_viewer/main.cljs
@@ -33,7 +33,9 @@
   (fsa/connect {:tap-name "analysis-viewer"})
   (fsa/trace-ref re-frame.db/app-db {:ref-name "re-frame-db"
                                      :ignore-keys [:maps/data ;; this one is super big
-                                                   #_:map/state]}) ;; this one changes a lot when zooming, dragging, etc
+                                                   :map/state ;; this one changes a lot when zooming, dragging, etc
+                                                   :animation/percentage ;; this one changes a lot
+                                                   ]}) 
   (let [{:keys [maps output]} (parse-url-qstring (subs js/window.location.search 1))]
     (re-frame/dispatch-sync [:map/initialize
                              (into ["WORLD"] (str/split maps #",") )

--- a/src/cljs/analysis_viewer/main.cljs
+++ b/src/cljs/analysis_viewer/main.cljs
@@ -23,11 +23,11 @@
 
 ;; Some discrete tree examples
 
-;; http://localhost:8021/?output-type=discrete-tree&output=a1195874-0bbe-4a8c-96f5-14cdf9097e02/985ecd9f-a9eb-425d-9795-7e92a81d2941.json&maps=AU,TZ
+;; http://localhost:8021/?output-type=discrete-tree&output=a1195874-0bbe-4a8c-96f5-14cdf9097e02/985ecd9f-a9eb-425d-9795-7e92a81d2941.json&maps=CN
 
 ;; Some bayes examples
 
-;; http://localhost:8021/?output-type=bayes&output=a1195874-0bbe-4a8c-96f5-14cdf9097e02/e9d1f428-0d26-42a0-bb7a-b9c14e59d9dd.json&maps=AU,TZ
+;; http://localhost:8021/?output-type=bayes&output=a1195874-0bbe-4a8c-96f5-14cdf9097e02/e9d1f428-0d26-42a0-bb7a-b9c14e59d9dd.json&maps=CN
 
 ;; Some timeslicer examples
 

--- a/src/cljs/analysis_viewer/map_emitter.cljs
+++ b/src/cljs/analysis_viewer/map_emitter.cljs
@@ -26,8 +26,8 @@
 
   all coordinates are in proj-coord [x y] where 0 <= x  <= 360, 0 <= y <= 180
   "
-  (:require [shared.math-utils :as math-utils]
-            [goog.string :as gstr]))
+  (:require [goog.string :as gstr]
+            [shared.math-utils :as math-utils]))
 
 (defn build-show-percentages-calculator [timeline]
   (let [{:keys [startTime endTime]} timeline
@@ -89,7 +89,7 @@
     (println (gstr/format "Continuous tree, got %d points, %d arcs, %d areas" (count points-objects) (count arcs-objects) (count area-objects)))
     objects))
 
-(defn discrete-tree-output->map-data [{:keys [timeline axisAttributes lineAttributes pointAttributes locations layers] :as data}]
+(defn discrete-tree-output->map-data [{:keys [timeline locations layers]}]
   (let [[counts-layer tree-layer] layers
         calc-show-percs (build-show-percentages-calculator timeline)
         all-points (concat (:points counts-layer) (:points tree-layer))
@@ -129,7 +129,7 @@
     (println (gstr/format "Discrete tree, got %d points, %d arcs" (count points-objects) (count arcs-objects)))
     objects))
 
-(defn bayes-output->map-data [{:keys [axisAttributes lineAttributes pointAttributes locations layers] :as data}]
+(defn bayes-output->map-data [{:keys [locations layers]}]
   (let [layer (first layers)
         all-points (:points layer)
         locations-index (->> locations
@@ -142,16 +142,15 @@
                                 (get locations-index)
                                 :coordinate))
         points-objects (->> all-points
-                            (map (fn [{:keys [id attributes] :as point}]
-                                   (let [coordinate (point-coordinate id)
-                                         count-attr (get attributes :count)]
+                            (map (fn [{:keys [id attributes]}]
+                                   (let [coordinate (point-coordinate id)]
                                      {:type :point
                                       :show-start 0
                                       :show-end 1
                                       :coord (calc-proj-coord coordinate)                                      
                                       :attrs attributes}))))
         arcs-objects (->> (:lines layer)
-                          (map (fn [{:keys [startPointId endPointId attributes] :as line}]
+                          (map (fn [{:keys [startPointId endPointId attributes]}]
                                  (let [start-point (get points-index startPointId)
                                        end-point (get points-index endPointId)]
                                    {:type :arc
@@ -166,7 +165,7 @@
     (println (gstr/format "Bayes analysis, got %d points, %d arcs" (count points-objects) (count arcs-objects)))
     objects))
 
-(defn timeslicer-output->map-data [{:keys [timeline areaAttributes layers] :as data}]
+(defn timeslicer-output->map-data [{:keys [timeline layers]}]
   (let [layer (first layers)
         calc-show-percs (build-show-percentages-calculator timeline)
         area-objects (->> (:areas layer)

--- a/src/cljs/analysis_viewer/map_emitter.cljs
+++ b/src/cljs/analysis_viewer/map_emitter.cljs
@@ -111,7 +111,7 @@
                                                :coord (calc-proj-coord coordinate)                                      
                                                :attrs attributes}
                                               (calc-show-percs point))
-                                       count-attr (assoc :radius-factor count-attr))))))
+                                       count-attr (assoc :radius (* 0.05 count-attr)))))))
         arcs-objects (->> (:lines tree-layer)
                           (map (fn [{:keys [startPointId endPointId attributes] :as line}]
                                  (let [start-point (get points-index startPointId)

--- a/src/cljs/analysis_viewer/map_emitter.cljs
+++ b/src/cljs/analysis_viewer/map_emitter.cljs
@@ -129,9 +129,8 @@
     (println (gstr/format "Discrete tree, got %d points, %d arcs" (count points-objects) (count arcs-objects)))
     (index-objects objects)))
 
-(defn bayes-output->map-data [{:keys [locations layers points lines]}]
-  (let [layer (first layers)
-        locations-index (->> locations
+(defn bayes-output->map-data [{:keys [locations points lines]}]
+  (let [locations-index (->> locations
                              (map (fn [l] [(:id l) l]))
                              (into {}))
         points-index (build-points-index points)        

--- a/src/cljs/analysis_viewer/map_emitter.cljs
+++ b/src/cljs/analysis_viewer/map_emitter.cljs
@@ -166,7 +166,22 @@
     (println (gstr/format "Bayes analysis, got %d points, %d arcs" (count points-objects) (count arcs-objects)))
     objects))
 
-(defn timeslicer-output->map-data [_]
-  ;; TODO: implement
-  (throw (js/Error. "Timeslicer map data emitter not implemented yet.")))
+(defn timeslicer-output->map-data [{:keys [timeline areaAttributes layers] :as data}]
+  (let [layer (first layers)
+        calc-show-percs (build-show-percentages-calculator timeline)
+        area-objects (->> (:areas layer)
+                          (map (fn [{:keys [polygon] :as area}]
+                                 (merge
+                                  {:type :area
+                                   :coords (->> (:coordinates polygon)
+                                                (mapv (fn [poly-point]
+                                                        (calc-proj-coord poly-point))))
+                                   :attrs {}}
+                                  (calc-show-percs area)))))
+        objects (->> area-objects
+                     (map-indexed (fn [idx o]
+                                    (assoc o :id idx))))]
+    (println timeline)
+    (println (gstr/format "Timeslicer, got %d areas" (count area-objects)))
+    objects))
 

--- a/src/cljs/analysis_viewer/map_emitter.cljs
+++ b/src/cljs/analysis_viewer/map_emitter.cljs
@@ -74,11 +74,16 @@
                                                 (mapv (fn [poly-point]
                                                         (calc-proj-coord poly-point))))
                                    :attrs {}}
-                                  (calc-show-percs area)))))
-        _ (println (gstr/format "Got %d points, %d arcs, %d areas" (count points-objects) (count arcs-objects) (count area-objects)))
+                                  (calc-show-percs area)))))        
         objects (->> (concat area-objects arcs-objects points-objects)
                      (map-indexed (fn [idx o]
                                     (assoc o :id idx))))]
+    (println timeline)
+    (println (gstr/format "Continuous tree, got %d points, %d arcs, %d areas" (count points-objects) (count arcs-objects) (count area-objects)))
+    (println (gstr/format "Start: %s(%d), End: %s(%d), Total time %ds"
+                          startTime start-time-millis
+                          endTime   end-time-millis
+                          timeline-millis))
     objects))
 
 (defn discrete-tree-output->map-data [_]

--- a/src/cljs/analysis_viewer/map_emitter.cljs
+++ b/src/cljs/analysis_viewer/map_emitter.cljs
@@ -26,7 +26,8 @@
 
   all coordinates are in proj-coord [x y] where 0 <= x  <= 360, 0 <= y <= 180
   "
-  (:require [shared.math-utils :as math-utils]))
+  (:require [shared.math-utils :as math-utils]
+            [goog.string :as gstr]))
 
 (defn continuous-tree-output->map-data [{:keys [timeline layers]}]  
   (let [layer (first layers) ;; current that format only use one layer
@@ -69,12 +70,13 @@
                           (map (fn [{:keys [polygon] :as area}]
                                  (merge
                                   {:type :area
-                                   :coords (->> polygon
+                                   :coords (->> (:coordinates polygon)
                                                 (mapv (fn [poly-point]
                                                         (calc-proj-coord poly-point))))
                                    :attrs {}}
                                   (calc-show-percs area)))))
-        objects (->> (concat points-objects arcs-objects area-objects)
+        _ (println (gstr/format "Got %d points, %d arcs, %d areas" (count points-objects) (count arcs-objects) (count area-objects)))
+        objects (->> (concat area-objects arcs-objects points-objects)
                      (map-indexed (fn [idx o]
                                     (assoc o :id idx))))]
     objects))

--- a/src/cljs/analysis_viewer/map_emitter.cljs
+++ b/src/cljs/analysis_viewer/map_emitter.cljs
@@ -52,6 +52,13 @@
        (map (fn [p] [(:id p) p]))
        (into {})))
 
+(defn index-objects [objs]
+  (->> objs
+       (map-indexed (fn [idx o]
+                      (let [id (str "object-" idx)]
+                        [id (assoc o :id id)])))
+       (into {})))
+
 (defn continuous-tree-output->map-data [{:keys [timeline points lines areas]}]  
   (let [calc-show-percs (build-show-percentages-calculator timeline)
         points-index (build-points-index points)
@@ -81,12 +88,10 @@
                                                         (calc-proj-coord poly-point))))
                                    :attrs {}}
                                   (calc-show-percs area)))))        
-        objects (->> (concat area-objects arcs-objects points-objects)
-                     (map-indexed (fn [idx o]
-                                    (assoc o :id idx))))]
+        objects (concat area-objects arcs-objects points-objects)]
     (println timeline)
     (println (gstr/format "Continuous tree, got %d points, %d arcs, %d areas" (count points-objects) (count arcs-objects) (count area-objects)))
-    objects))
+    (index-objects objects)))
 
 (defn discrete-tree-output->map-data [{:keys [timeline locations points lines counts]}]
   (let [calc-show-percs (build-show-percentages-calculator timeline)
@@ -120,12 +125,10 @@
                                      :to-coord (calc-proj-coord (point-coordinate (:id end-point)))
                                      :attrs attributes}
                                     (calc-show-percs line))))))
-        objects (->> (concat arcs-objects points-objects)
-                     (map-indexed (fn [idx o]
-                                    (assoc o :id idx))))]
+        objects (concat arcs-objects points-objects)]
     (println timeline)
     (println (gstr/format "Discrete tree, got %d points, %d arcs" (count points-objects) (count arcs-objects)))
-    objects))
+    (index-objects objects)))
 
 (defn bayes-output->map-data [{:keys [locations layers points lines]}]
   (let [layer (first layers)
@@ -156,9 +159,7 @@
                                     :from-coord (calc-proj-coord (point-coordinate (:id start-point)))
                                     :to-coord (calc-proj-coord (point-coordinate (:id end-point)))
                                     :attrs attributes}))))
-        objects (->> (concat arcs-objects points-objects)
-                     (map-indexed (fn [idx o]
-                                    (assoc o :id idx))))]
+        objects (concat arcs-objects points-objects)]
     (println (gstr/format "Bayes analysis, got %d points, %d arcs" (count points-objects) (count arcs-objects)))
-    objects))
+    (index-objects objects)))
 

--- a/src/cljs/analysis_viewer/map_emitter.cljs
+++ b/src/cljs/analysis_viewer/map_emitter.cljs
@@ -107,14 +107,13 @@
                                 :coordinate))
         points-objects (->> all-points
                             (map (fn [{:keys [id attributes] :as point}]
-                                   (let [coordinate (point-coordinate id)
-                                         count-attr (get attributes :count)]
+                                   (let [coordinate (point-coordinate id)]
                                      (cond-> (merge
                                               {:type :point
                                                :coord (calc-proj-coord coordinate)                                      
-                                               :attrs attributes}
-                                              (calc-show-percs point))
-                                       count-attr (assoc :radius (* 0.05 count-attr)))))))
+                                               :attrs attributes
+                                               :count-attr (get attributes :count)}
+                                              (calc-show-percs point)))))))
         arcs-objects (->> lines
                           (map (fn [{:keys [startPointId endPointId attributes] :as line}]
                                  (let [start-point (get points-index startPointId)

--- a/src/cljs/analysis_viewer/subs.cljs
+++ b/src/cljs/analysis_viewer/subs.cljs
@@ -57,10 +57,14 @@
    (:analysis/data db)))
 
 (defn color-object [obj [attr-key [from to] [color-from color-to]]]
-  (let [obj-attr-val (get (:attrs obj) (keyword attr-key))
-        perc (/ (- obj-attr-val from)  (- to from))
-        color (math-utils/calculate-color color-from color-to perc)]
-    (assoc obj :attr-color color)))
+  
+  (if-let [obj-attr-val (get (:attrs obj) (keyword attr-key))]
+    (let [perc (/ (- obj-attr-val from)  (- to from))
+          color (math-utils/calculate-color color-from color-to perc)]
+      (assoc obj :attr-color color))
+    (do
+      (println "The object " obj "doesn't contain attr " attr-key)
+     obj)))
 
 (defn color-data-objects [data obj-type attr]
   (->> data

--- a/src/cljs/analysis_viewer/subs.cljs
+++ b/src/cljs/analysis_viewer/subs.cljs
@@ -59,6 +59,20 @@
                          (assoc tick :x (+ (* idx tick-gap) ticks-x-base))))))))
 
 (reg-sub
+ :map/parameters
+ :<- [:ui/parameters]
+ :<- [:switch-buttons/states]
+ (fn [[params buttons-states] _]
+   {:map-fill-color "#ffffff"
+    :background-color "#ECEFF8"
+    :map-stroke-color (if (get buttons-states :map-borders)
+                        (get params :map-borders-color "#079DAB")
+                        :transparent)
+    :map-text-color (get params :map-borders-color "#079DAB")
+    :line-color "#B20707"
+    :data-point-color "#DD0808"}))
+
+(reg-sub
  :collapsible-tabs/tabs
  (fn [db _]
    (:ui.collapsible-tabs/tabs db)))

--- a/src/cljs/analysis_viewer/subs.cljs
+++ b/src/cljs/analysis_viewer/subs.cljs
@@ -138,25 +138,28 @@
           (map-indexed (fn [idx tick]
                          (assoc tick :x (+ (* idx tick-gap) ticks-x-base))))))))
 
+(defn build-map-parameters [ui-params switch-buttons-states]
+  {:poly-fill-color "#ffffff"
+   :poly-stroke-color (if (get switch-buttons-states :map-borders?)
+                        (get ui-params :map-borders-color "#079DAB")
+                        :transparent)
+   :poly-stroke-width "0.02"
+   :line-color "#B20707"
+   :line-width "0.1"
+   :text-color (if (get switch-buttons-states :labels?)
+                 (get ui-params :map-borders-color "#079DAB")
+                 :transparent)
+   :text-size (:labels-size ui-params)                         
+   :point-color (:nodes-color ui-params)
+   :point-radius (:nodes-size ui-params)
+   :background-color "#ECEFF8"})
+
 (reg-sub
  :map/parameters
  :<- [:ui/parameters]
  :<- [:switch-buttons/states]
  (fn [[params buttons-states] [_]]
-   {:poly-fill-color "#ffffff"
-    :poly-stroke-color (if (get buttons-states :map-borders?)
-                         (get params :map-borders-color "#079DAB")
-                         :transparent)
-    :poly-stroke-width "0.02"
-    :line-color "#B20707"
-    :line-width "0.1"
-    :text-color (if (get buttons-states :labels?)
-                  (get params :map-borders-color "#079DAB")
-                  :transparent)
-    :text-size (:labels-size params)                         
-    :point-color (:nodes-color params)
-    :point-radius (:nodes-size params)
-    :background-color "#ECEFF8"}))
+   (build-map-parameters params buttons-states)))
 
 (reg-sub
  :collapsible-tabs/tabs

--- a/src/cljs/analysis_viewer/subs.cljs
+++ b/src/cljs/analysis_viewer/subs.cljs
@@ -70,3 +70,13 @@
    (get-in tabs [parent-id tab-id])))
 
 
+(reg-sub
+ :ui/parameters
+ (fn [db _]
+   (:ui/parameters db)))
+
+(reg-sub
+ :parameters/selected 
+ :<- [:ui/parameters]
+ (fn [parameters [_ id]]
+   (get parameters id)))

--- a/src/cljs/analysis_viewer/subs.cljs
+++ b/src/cljs/analysis_viewer/subs.cljs
@@ -11,12 +11,12 @@
     (assoc maps :map-box (svg-renderer/geo-json-bounding-box maps))))
 
 (reg-sub
- ::maps
+ :maps/all-maps-data
  (fn [db _]
   (:maps/data db)))
 
 (reg-sub
- ::map-state
+ :map/state
  (fn [db _]
    (:map/state db)))
 
@@ -32,33 +32,33 @@
 
 (reg-sub
  :map/scale
- :<- [::map-state]
+ :<- [:map/state]
  (fn [map-state _]
    (:scale map-state)))
 
 (reg-sub
- ::map-state-show
- :<- [::map-state]
+ :map.state/show-world?
+ :<- [:map/state]
  (fn [{:keys [show-world?]}]
    show-world?))
 
 (reg-sub
- ::map-data
- :<- [::maps]
- :<- [::map-state-show]
+ :map/data
+ :<- [:maps/all-maps-data]
+ :<- [:map.state/show-world?]
  (fn [[maps show-world?] _]
    (let [hide-world? (false? show-world?)]
      (geo-json-data-map (cond->> maps
                           hide-world? (remove #(zero? (:map/z-index %))))))))
 
 (reg-sub
- ::analysis-data
+ :analysis/data
  (fn [db _]
    (:analysis/data db)))
 
 (reg-sub
- ::analysis-data-timeline
- :<- [::analysis-data]
+ :analysis/data-timeline
+ :<- [:analysis/data]
  (fn [_ _]
    (let [tick-gap 10
          ticks-x-base 10]

--- a/src/cljs/analysis_viewer/subs.cljs
+++ b/src/cljs/analysis_viewer/subs.cljs
@@ -1,7 +1,6 @@
 (ns analysis-viewer.subs
   (:require [analysis-viewer.svg-renderer :as svg-renderer]
-            [re-frame.core :refer [reg-sub]]
-            [shared.math-utils :as math-utils]))
+            [re-frame.core :refer [reg-sub]]))
 
 (defn geo-json-data-map [db-maps]
   (let [maps {:type "FeatureCollection"
@@ -73,7 +72,7 @@
  :map/parameters
  :<- [:ui/parameters]
  :<- [:switch-buttons/states]
- (fn [[params buttons-states] [_ param-id]]
+ (fn [[params buttons-states] [_]]
    {:map-fill-color "#ffffff"
     :background-color "#ECEFF8"
     :map-stroke-color (if (get buttons-states :map-borders)

--- a/src/cljs/analysis_viewer/subs.cljs
+++ b/src/cljs/analysis_viewer/subs.cljs
@@ -21,6 +21,12 @@
    (:map/state db)))
 
 (reg-sub
+ :map/scale
+ :<- [::map-state]
+ (fn [map-state _]
+   (:scale map-state)))
+
+(reg-sub
  ::map-state-show
  :<- [::map-state]
  (fn [{:keys [show-world?]}]
@@ -62,13 +68,13 @@
  :map/parameters
  :<- [:ui/parameters]
  :<- [:switch-buttons/states]
- (fn [[params buttons-states] _]
+ (fn [[params buttons-states] [_ param-id]]
    {:map-fill-color "#ffffff"
     :background-color "#ECEFF8"
     :map-stroke-color (if (get buttons-states :map-borders)
                         (get params :map-borders-color "#079DAB")
                         :transparent)
-    :map-text-color (get params :map-borders-color "#079DAB")
+    :map-text-color (get params :map-borders-color "#079DAB")                     
     :line-color "#B20707"
     :data-point-color "#DD0808"}))
 
@@ -96,8 +102,10 @@
 
 (reg-sub
  :ui/parameters
- (fn [db _]
-   (:ui/parameters db)))
+ (fn [db [_ param-id]]
+   (if param-id
+     (get-in db [:ui/parameters param-id])
+     (:ui/parameters db))))
 
 (reg-sub
  :parameters/selected 

--- a/src/cljs/analysis_viewer/subs.cljs
+++ b/src/cljs/analysis_viewer/subs.cljs
@@ -69,6 +69,16 @@
  (fn [tabs [_ parent-id tab-id]]
    (get-in tabs [parent-id tab-id])))
 
+(reg-sub
+ :switch-buttons/states
+ (fn [db _]
+   (:ui.switch-buttons/states db)))
+
+(reg-sub
+ :switch-buttons/on?
+ :<- [:switch-buttons/states]
+ (fn [states [_ id]]
+   (get states id)))
 
 (reg-sub
  :ui/parameters

--- a/src/cljs/analysis_viewer/subs.cljs
+++ b/src/cljs/analysis_viewer/subs.cljs
@@ -21,6 +21,16 @@
    (:map/state db)))
 
 (reg-sub
+ :animation/percentage
+ (fn [db _]
+   (:animation/percentage db)))
+
+(reg-sub
+ :animation/state
+ (fn [db _]
+   (:animation/state db)))
+
+(reg-sub
  :map/scale
  :<- [::map-state]
  (fn [map-state _]
@@ -40,11 +50,6 @@
    (let [hide-world? (false? show-world?)]
      (geo-json-data-map (cond->> maps
                           hide-world? (remove #(zero? (:map/z-index %))))))))
-
-(reg-sub
- ::map-view-box
- (fn [{:keys [map-view-box-center map-view-box-radius]} _]
-   (math-utils/outscribing-rectangle map-view-box-center map-view-box-radius)))
 
 (reg-sub
  ::analysis-data

--- a/src/cljs/analysis_viewer/subs.cljs
+++ b/src/cljs/analysis_viewer/subs.cljs
@@ -56,6 +56,11 @@
    (:analysis/data db)))
 
 (reg-sub
+ :analysis.data/type
+ (fn [db _]
+   (:analysis.data/type db)))
+
+(reg-sub
  :analysis/selected-object-id
  (fn [db _]
    (:analysis/selected-object-id db)))
@@ -102,14 +107,20 @@
  :<- [:ui/parameters]
  :<- [:switch-buttons/states]
  (fn [[params buttons-states] [_]]
-   {:map-fill-color "#ffffff"
-    :background-color "#ECEFF8"
-    :map-stroke-color (if (get buttons-states :map-borders)
-                        (get params :map-borders-color "#079DAB")
-                        :transparent)
-    :map-text-color (get params :map-borders-color "#079DAB")                     
+   {:poly-fill-color "#ffffff"
+    :poly-stroke-color (if (get buttons-states :map-borders?)
+                         (get params :map-borders-color "#079DAB")
+                         :transparent)
+    :poly-stroke-width "0.02"
     :line-color "#B20707"
-    :data-point-color "#DD0808"}))
+    :line-width "0.1"
+    :text-color (if (get buttons-states :labels?)
+                  (get params :map-borders-color "#079DAB")
+                  :transparent)
+    :text-size (:labels-size params)                         
+    :point-color (:nodes-color params)
+    :point-radius (:nodes-size params)
+    :background-color "#ECEFF8"}))
 
 (reg-sub
  :collapsible-tabs/tabs

--- a/src/cljs/analysis_viewer/subs.cljs
+++ b/src/cljs/analysis_viewer/subs.cljs
@@ -56,6 +56,35 @@
    (:analysis/data db)))
 
 (reg-sub
+ :analysis/selected-object-id
+ (fn [db _]
+   (:analysis/selected-object-id db)))
+
+(reg-sub
+ :analysis/possible-objects-ids
+ (fn [db _]
+   (:analysis/possible-objects-ids db)))
+
+(reg-sub
+ :analysis/selected-object
+ :<- [:analysis/data]
+ :<- [:analysis/selected-object-id]
+ (fn [[objects-map sel-obj-id] _]
+   (get objects-map sel-obj-id)))
+
+(reg-sub
+ :analysis/possible-objects
+ :<- [:analysis/data]
+ :<- [:analysis/possible-objects-ids]
+ (fn [[objects-map pos-obj-ids] _]
+   (vals (select-keys objects-map pos-obj-ids))))
+
+(reg-sub
+ :map/popup-coord
+ (fn [db _]
+   (:map/popup-coord db)))
+
+(reg-sub
  :analysis/data-timeline
  :<- [:analysis/data]
  (fn [_ _]

--- a/src/cljs/analysis_viewer/svg_renderer.cljs
+++ b/src/cljs/analysis_viewer/svg_renderer.cljs
@@ -4,9 +4,8 @@
   Api :
   - geojson->svg
   "
-  (:require [clojure.string :as str]
-            [shared.math-utils :as math-utils]
-            [clojure.spec.alpha :as s]))
+  (:require [clojure.spec.alpha :as s]
+            [clojure.string :as str]))
 
 (def ^:dynamic *coord-transform-fn* identity)
 

--- a/src/cljs/analysis_viewer/views.cljs
+++ b/src/cljs/analysis_viewer/views.cljs
@@ -78,13 +78,6 @@
 (def wheel-button 1)
 (def right-button 2)
 
-(def theme {:map-fill-color "#ffffff"
-            :background-color "#ECEFF8"
-            :map-stroke-color "#079DAB"
-            :map-text-color "#079DAB"
-            :line-color "#B20707"
-            :data-point-color "#DD0808"})
-
 (def animation-delta-t 50)
 (def animation-increment 0.02)
 
@@ -143,13 +136,10 @@
 
 (defn map-group []
   (let [geo-json-map @(re-frame/subscribe [::subs/map-data])
-        map-borders-color @(re-frame/subscribe [:parameters/selected :map-borders-color])]
+        map-options @(re-frame/subscribe [:map/parameters])]    
     (when geo-json-map
       [:g {}
-       (binding [svg-renderer/*theme* (assoc theme
-                                             :map-stroke-color map-borders-color
-                                             :map-text-color map-borders-color)]
-         (svg-renderer/geojson->svg geo-json-map))])))
+       (svg-renderer/geojson->svg geo-json-map map-options)])))
 
 (defn data-group [time]
   (let [analysis-data  @(re-frame/subscribe [::subs/analysis-data])
@@ -172,7 +162,7 @@
             scale (or scale 1)
             [translate-x translate-y] translate]
         [:div.animated-data-map {:style {} #_{:height (str events.maps/map-screen-height "px")
-                                         :width  (str events.maps/map-screen-width  "px")}
+                                              :width  (str events.maps/map-screen-width  "px")}
                                  :on-wheel (fn [evt]
                                              (let [x (-> evt .-nativeEvent .-offsetX)
                                                    y (-> evt .-nativeEvent .-offsetY)]
@@ -222,7 +212,7 @@
                                                          :x (/ events.maps/map-screen-width 2)
                                                          :y (/ events.maps/map-screen-height 2)}])
                      :class "map-zoom"}]]
-                  
+         
          ;; SVG data map
          [:svg {:xmlns "http://www.w3.org/2000/svg"
                 :xmlns:amcharts "http://amcharts.com/ammap"
@@ -239,7 +229,7 @@
             [:stop {:offset "100%" :stop-color "#B20707"}]]]
 
           ;; map background
-          [:rect {:x "0" :y "0" :width "100%" :height "100%" :fill (:background-color theme)}]
+          [:rect {:x "0" :y "0" :width "100%" :height "100%" :fill "#ECEFF8"}]
           
           ;; map and data svg
           [:g {:transform (gstr/format "translate(%f %f) scale(%f %f)"
@@ -253,12 +243,10 @@
           (when zoom-rectangle
             (let [[x1 y1] (:origin zoom-rectangle)
                   [x2 y2] (:current zoom-rectangle)]
-              [:rect {:x x1 :y y1 :width (- x2 x1) :height (- y2 y1) :stroke (:data-point-color theme) :fill :transparent}]))]
+              [:rect {:x x1 :y y1 :width (- x2 x1) :height (- y2 y1) :stroke "#DD0808" :fill :transparent}]))]
          [animation-controls {:dec-time-fn dect
                               :inc-time-fn inct
-                              :time-ref time-ref}]])
-      
-      )))
+                              :time-ref time-ref}]]))))
 
 (defn top-bar []
   [:div.top-bar

--- a/src/cljs/analysis_viewer/views.cljs
+++ b/src/cljs/analysis_viewer/views.cljs
@@ -3,7 +3,7 @@
   Also handles animations."
   (:require [analysis-viewer.subs :as subs]
             [analysis-viewer.events.maps :as events.maps]
-            [analysis-viewer.components :refer [switch-button]]
+            [analysis-viewer.components :refer [switch-button slider]]
             [analysis-viewer.svg-renderer :as svg-renderer]
             [clojure.string :as str]
             [goog.string :as gstr]
@@ -81,17 +81,7 @@
 (def animation-delta-t 50)
 (def animation-increment 0.02)
 
-(defn zoom-bar [{:keys [zoom-perc zoom-inc-fn zoom-dec-fn class]}]
-  [:div.zoom-bar {:class class}
-   [:button {:on-click zoom-inc-fn} "+"]
-   [:div {:width "6px" :height "100%"}
-    [:svg 
-     [:line {:x1 "10" :y1 "100" :x2 "10" :y2 "0" :stroke "#DEDEE8" :stroke-width 3}]
-     [:line {:x1 "10" :y1 "100" :x2 "10" :y2 "0" :stroke "#EEBE53" :stroke-width 3
-             :stroke-dasharray 100
-             :stroke-dashoffset zoom-perc}]
-     [:rect {:x "4" :y (str (- zoom-perc 6)) :width "12" :height "12" :fill "white" :stroke "grey"}]]]
-   [:button {:on-click zoom-dec-fn} "-"]])
+
 
 (defn animation-controls [{:keys [dec-time-fn inc-time-fn time-ref]}]
   (let [ticks-data @(subscribe [::subs/analysis-data-timeline])
@@ -102,7 +92,7 @@
         full-length (apply max (map :x ticks-data))
         play-line-x (* @time-ref full-length)]
     [:div.animation-controls
-     [zoom-bar {:zoom-perc zoom-perc}]
+     [slider {:zoom-perc zoom-perc}]
      [:div.inner
       [:div.buttons
        [:i.zmdi.zmdi-skip-previous {:on-click dec-time-fn} ""]    
@@ -205,14 +195,14 @@
                                             (dispatch [:map/zoom-rectangle-release])))}
           [:div.zoom-bar-outer
            [:div.zoom-bar-back]
-           [zoom-bar {:zoom-perc (- 100 (/ (* 100 scale) events.maps/max-scale ))
-                      :zoom-inc-fn #(dispatch [:map/zoom {:delta -50
-                                                          :x (/ events.maps/map-screen-width 2)
-                                                          :y (/ events.maps/map-screen-height 2)}])
-                      :zoom-dec-fn #(dispatch [:map/zoom {:delta 50
-                                                          :x (/ events.maps/map-screen-width 2)
-                                                          :y (/ events.maps/map-screen-height 2)}])
-                      :class "map-zoom"}]]
+           [slider {:zoom-perc (- 100 (/ (* 100 scale) events.maps/max-scale ))
+                    :zoom-inc-fn #(dispatch [:map/zoom {:delta -50
+                                                        :x (/ events.maps/map-screen-width 2)
+                                                        :y (/ events.maps/map-screen-height 2)}])
+                    :zoom-dec-fn #(dispatch [:map/zoom {:delta 50
+                                                        :x (/ events.maps/map-screen-width 2)
+                                                        :y (/ events.maps/map-screen-height 2)}])
+                    :class "map-zoom"}]]
           
           ;; SVG data map
           [:svg {:xmlns "http://www.w3.org/2000/svg"
@@ -293,6 +283,11 @@
            [:i.zmdi.zmdi-check])
          ])]]))
 
+(defn polygon-opacity []
+  [:div
+   ]
+  )
+
 (defn controls-side-bar [time]
   [:div.side-bar
    [:div.tabs
@@ -306,7 +301,7 @@
                                  :child [map-color-chooser]}
                                 {:title "Polygon opacity"
                                  :id :polygon-opacity
-                                 :child [:div "aaaaaaaaaaa"]}]}]
+                                 :child [polygon-opacity]}]}]
     [collapsible-tabs {:title "Filters"
                        :id :filters
                        :childs [{:title "States prob"

--- a/src/cljs/analysis_viewer/views.cljs
+++ b/src/cljs/analysis_viewer/views.cljs
@@ -24,7 +24,7 @@
         [x1 y1] coord]
     ;; TODO: add attrs
     [:g {:style {:display (if show? :block :none)}}
-     [:circle {:cx x1 :cy y1 :r (/ 0.4 scale) :stroke :red :fill :blue}]]))
+     [:circle {:cx x1 :cy y1 :r (/ 0.4 scale) :stroke "#DD0808" :fill "#B20707"}]]))
 
 (defn svg-area-object [{:keys [coords show-start show-end]} _ time-perc]
   (let [show? (<= show-start time-perc show-end)]
@@ -35,7 +35,7 @@
                     (map (fn [coord] (str/join " " coord)))
                     (str/join ","))
        
-       :fill :red
+       :fill "#9E15E6"
        :opacity "0.3"}]]))
 
 (defn svg-quad-curve-object [{:keys [from-coord to-coord show-start show-end]} scale time-perc]
@@ -217,8 +217,8 @@
           ;; gradients definitions
           [:defs {}
            [:linearGradient {:id "grad"}
-            [:stop {:offset "0%" :stop-color :red}]
-            [:stop {:offset "100%" :stop-color :yellow}]]]
+            [:stop {:offset "0%" :stop-color "#DD0808"}]
+            [:stop {:offset "100%" :stop-color "#B20707"}]]]
 
           ;; map background
           [:rect {:x "0" :y "0" :width "100%" :height "100%" :fill (:background-color theme)}]

--- a/src/cljs/analysis_viewer/views.cljs
+++ b/src/cljs/analysis_viewer/views.cljs
@@ -86,7 +86,7 @@
 (defn animation-controls [{:keys [dec-time-fn inc-time-fn time-ref]}]
   (let [time @(subscribe [:animation/percentage])
         playing? (= :play @(subscribe [:animation/state]))
-        ticks-data @(subscribe [::subs/analysis-data-timeline])
+        ticks-data @(subscribe [:analysis/data-timeline])
         zoom-perc 50
         ticks-y-base 80
         ticks-bars-y-base (- ticks-y-base 11)
@@ -129,7 +129,7 @@
                label])])]]]]]))
 
 (defn map-group []
-  (let [geo-json-map @(re-frame/subscribe [::subs/map-data])
+  (let [geo-json-map @(re-frame/subscribe [:map/data])
         map-options @(re-frame/subscribe [:map/parameters])]    
     (when geo-json-map
       [:g {}
@@ -137,8 +137,8 @@
 
 (defn data-group []
   (let [time @(re-frame/subscribe [:animation/percentage])
-        analysis-data  @(re-frame/subscribe [::subs/analysis-data])
-        {:keys [scale]} @(re-frame/subscribe [::subs/map-state])
+        analysis-data  @(re-frame/subscribe [:analysis/data])
+        {:keys [scale]} @(re-frame/subscribe [:map/state])
         params @(subscribe [:ui/parameters])]
     (when analysis-data
       [:g {}
@@ -148,7 +148,7 @@
 
 (defn animated-data-map []
   (fn []      
-    (let [{:keys [grab translate scale zoom-rectangle]} @(re-frame/subscribe [::subs/map-state])
+    (let [{:keys [grab translate scale zoom-rectangle]} @(re-frame/subscribe [:map/state])
           scale (or scale 1)
           [translate-x translate-y] translate]
       [:div.animated-data-map

--- a/src/cljs/analysis_viewer/views.cljs
+++ b/src/cljs/analysis_viewer/views.cljs
@@ -296,10 +296,11 @@
    [slider {:inc-buttons 0.1
             :min-val 0
             :max-val 1
-            :length 100
+            :length 140
             :vertical? false
             :subs-vec [:ui/parameters :polygon-opacity]
-            :ev-vec [:parameters/select :polygon-opacity]}]])
+            :ev-vec [:parameters/select :polygon-opacity]}]
+   ])
 
 (defn controls-side-bar [time]
   [:div.side-bar

--- a/src/cljs/analysis_viewer/views.cljs
+++ b/src/cljs/analysis_viewer/views.cljs
@@ -400,17 +400,16 @@
       (for [a (keys attributes)]
         ^{:key (str a)}
         [:option {:value a} a])]
-     [:div
-      [:input (cond-> {:type :color
-                       :on-change #(dispatch [:parameters/select key [attr-key
-                                                                      attr-range
-                                                                      [(-> % .-target .-value) color-to]]])}
-                color-from (assoc :value color-from))]
-      [:input (cond-> {:type :color
-                       :on-change #(dispatch [:parameters/select key [attr-key
-                                                                      attr-range
-                                                                      [color-from (-> % .-target .-value)]]])}
-                color-to (assoc :value color-to))]]]))
+     [:input (cond-> {:type :color
+                      :on-change #(dispatch [:parameters/select key [attr-key
+                                                                     attr-range
+                                                                     [(-> % .-target .-value) color-to]]])}
+               color-from (assoc :value color-from))]
+     [:input (cond-> {:type :color
+                      :on-change #(dispatch [:parameters/select key [attr-key
+                                                                     attr-range
+                                                                     [color-from (-> % .-target .-value)]]])}
+               color-to (assoc :value color-to))]]))
 
 (defn continuous-tree-map-settings []
   [:div.map-settings
@@ -425,25 +424,23 @@
 
    [attribute-color-chooser :transitions-attribute]
 
-   [:div
-    [:label "Curvature"]
-    [slider {:inc-buttons 0.1
-             :min-val 0.1
-             :max-val 2
-             :length 140
-             :vertical? false
-             :subs-vec [:ui/parameters :transitions-curvature]
-             :ev-vec [:parameters/select :transitions-curvature]}]]
+   [:label "Curvature"]
+   [slider {:inc-buttons 0.1
+            :min-val 0.1
+            :max-val 2
+            :length 140
+            :vertical? false
+            :subs-vec [:ui/parameters :transitions-curvature]
+            :ev-vec [:parameters/select :transitions-curvature]}]
 
-   [:div
-    [:label "Width"]
-    [slider {:inc-buttons 0.05
-             :min-val 0
-             :max-val 0.3
-             :length 140
-             :vertical? false
-             :subs-vec [:ui/parameters :transitions-width]
-             :ev-vec [:parameters/select :transitions-width]}]]])
+   [:label "Width"]
+   [slider {:inc-buttons 0.05
+            :min-val 0
+            :max-val 0.3
+            :length 140
+            :vertical? false
+            :subs-vec [:ui/parameters :transitions-width]
+            :ev-vec [:parameters/select :transitions-width]}]])
 
 (defn continuous-polygons-settings []
   [:div.polygons-settings
@@ -497,6 +494,7 @@
 (defn discrete-circles-settings []
   [:div.circles-settings
    [color-chooser {:param-name :circles-color}]
+   [attribute-color-chooser :circles-attribute]
    [:label "Size"]
    [slider {:inc-buttons 0.1
             :min-val 0
@@ -509,6 +507,7 @@
 (defn discrete-nodes-settings []
   [:div.nodes-settings
    [color-chooser {:param-name :nodes-color}]
+   [attribute-color-chooser :nodes-attribute]
    [:label "Size"]
    [slider {:inc-buttons 0.1
             :min-val 0

--- a/src/cljs/analysis_viewer/views.cljs
+++ b/src/cljs/analysis_viewer/views.cljs
@@ -1,9 +1,8 @@
 (ns analysis-viewer.views
   "Render maps and analysis data as hiccup svg vectors.
   Also handles animations."
-  (:require [analysis-viewer.subs :as subs]
+  (:require [analysis-viewer.components :refer [switch-button slider]]
             [analysis-viewer.events.maps :as events.maps]
-            [analysis-viewer.components :refer [switch-button slider]]
             [analysis-viewer.svg-renderer :as svg-renderer]
             [clojure.string :as str]
             [goog.string :as gstr]
@@ -22,7 +21,7 @@
 ;; as svg elements                                                                            ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defn svg-point-object [{:keys [coord show-start show-end radius-factor]} scale time-perc params]
+(defn svg-point-object [{:keys [coord show-start show-end radius-factor]} _ time-perc _]
   (let [show? (<= show-start time-perc show-end)
         [x1 y1] coord]
     ;; TODO: add attrs
@@ -41,7 +40,7 @@
        :fill "#9E15E6"
        :opacity (:polygon-opacity params)}]]))
 
-(defn svg-quad-curve-object [{:keys [from-coord to-coord show-start show-end]} scale time-perc params]
+(defn svg-quad-curve-object [{:keys [from-coord to-coord show-start show-end]} scale time-perc _]
   (let [show? (<= show-start time-perc show-end)
         clip-perc (when show?
                     (/ (- time-perc show-start)
@@ -85,11 +84,10 @@
 
 
 
-(defn animation-controls [{:keys [dec-time-fn inc-time-fn time-ref]}]
+(defn animation-controls []
   (let [time @(subscribe [:animation/percentage])
         playing? (= :play @(subscribe [:animation/state]))
         ticks-data @(subscribe [:analysis/data-timeline])
-        zoom-perc 50
         ticks-y-base 80
         ticks-bars-y-base (- ticks-y-base 11)
         ticks-bars-full 50                

--- a/src/cljs/analysis_viewer/views.cljs
+++ b/src/cljs/analysis_viewer/views.cljs
@@ -96,7 +96,7 @@
      [:line {:x1 "10" :y1 "100" :x2 "10" :y2 "0" :stroke "#EEBE53" :stroke-width 3
              :stroke-dasharray 100
              :stroke-dashoffset zoom-perc}]
-     [:rect {:x "5" :y (str (- zoom-perc 6)) :width "12" :height "12" :fill "white" :stroke "grey"}]]]
+     [:rect {:x "4" :y (str (- zoom-perc 6)) :width "12" :height "12" :fill "white" :stroke "grey"}]]]
    [:button {:on-click zoom-dec-fn} "-"]])
 
 (defn animation-controls [{:keys [dec-time-fn inc-time-fn time-ref]}]
@@ -141,10 +141,13 @@
                label])])]]]]]))
 
 (defn map-group []
-  (let [geo-json-map @(re-frame/subscribe [::subs/map-data])]
+  (let [geo-json-map @(re-frame/subscribe [::subs/map-data])
+        map-borders-color @(re-frame/subscribe [:parameters/selected :map-borders-color])]
     (when geo-json-map
       [:g {}
-       (binding [svg-renderer/*theme* theme]
+       (binding [svg-renderer/*theme* (assoc theme
+                                             :map-stroke-color map-borders-color
+                                             :map-text-color map-borders-color)]
          (svg-renderer/geojson->svg geo-json-map))])))
 
 (defn data-group [time]
@@ -278,6 +281,22 @@
       ^{:key (str (:id c))}
       [collapsible-tab id c])]])
 
+(defn map-color-chooser []
+  (let [colors ["#079DAB" "#3428CA" "#757295" "#DD0808" "#EEBE53" "#B20707" "#ECEFF8" "#FBFCFE" "#DEDEE9"
+                "#266C08" "#C76503" "#1C58D0" "#A5387B" "#1C58D9" "#3A3668" "#757299" "#DEDEE8" "#3428CB"]
+        selected-color @(subscribe [:parameters/selected :map-borders-color])]
+    [:div.map-color-chooser
+     [:div.colors
+      (for [c colors]
+        ^{:key c}
+        [:div.color {:style {:background-color c}
+                     :on-click (fn [evt]
+                                 (.stopPropagation evt)
+                                 (dispatch [:parameters/select :map-borders-color c]))}
+         (when (= selected-color c)
+           [:i.zmdi.zmdi-check])
+         ])]]))
+
 (defn controls-side-bar [time]
   [:div.side-bar
    [:div.tabs
@@ -288,7 +307,7 @@
                                  :child [:div "XXXXXXX"]}
                                 {:title "Map Color"
                                  :id :map-color
-                                 :child [:div "yyyyyyyy"]}
+                                 :child [map-color-chooser]}
                                 {:title "Polygon opacity"
                                  :id :polygon-opacity
                                  :child [:div "aaaaaaaaaaa"]}]}]

--- a/src/cljs/analysis_viewer/views.cljs
+++ b/src/cljs/analysis_viewer/views.cljs
@@ -34,10 +34,9 @@
       {:points (->> coords
                     (map (fn [coord] (str/join " " coord)))
                     (str/join ","))
-       :stroke :red
-       :fill :blue
-       ;; TODO: make this depend on scale
-       :stroke-width "0.02"}]]))
+       
+       :fill :red
+       :opacity "0.3"}]]))
 
 (defn svg-quad-curve-object [{:keys [from-coord to-coord show-start show-end]} scale time-perc]
   (let [show? (<= show-start time-perc show-end)

--- a/src/cljs/analysis_viewer/views.cljs
+++ b/src/cljs/analysis_viewer/views.cljs
@@ -21,7 +21,7 @@
 ;; as svg elements                                                                            ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defn svg-point-object [{:keys [coord show-start show-end count-attr id]} scale time-perc params]
+(defn svg-point-object [{:keys [coord show-start show-end count-attr id]} _ time-perc params]
   (let [{:keys [nodes? circles? nodes-radius nodes-color circles-radius circles-color]} params
         point-type (if count-attr :circle :node)
         show? (and (<= show-start time-perc show-end)
@@ -59,7 +59,7 @@
        :fill polygons-color
        :opacity polygons-opacity}]]))
 
-(defn svg-quad-curve-object [{:keys [from-coord to-coord show-start show-end id attr-color]} scale time-perc params]
+(defn svg-quad-curve-object [{:keys [from-coord to-coord show-start show-end id attr-color]} _ time-perc params]
   (let [{:keys [transitions? transitions-color transitions-width transitions-curvature missiles?]} params
         show? (and (<= show-start time-perc show-end)
                    transitions?)

--- a/src/cljs/analysis_viewer/views.cljs
+++ b/src/cljs/analysis_viewer/views.cljs
@@ -53,7 +53,8 @@
         curve-path-info {:d (str "M " x1 " " y1 " Q " f1x " " f1y " " x2 " " y2)
                          :stroke "url(#grad)"
                          :stroke-width (/ 0.6 scale)
-                         :fill :transparent}]
+                         :fill :transparent}
+        misile-size 0.3]
     ;; TODO: add attrs
     [:g {:style {:display (if show? :block :none)}}
      [:circle {:cx x1 :cy y1 :r 0.3 #_(/ 0.4 scale) :stroke :red :fill :blue}] 
@@ -63,9 +64,9 @@
               ;; animated dashed curves
               (let [c-length (int (math-utils/quad-curve-length x1 y1 f1x f1y x2 y2))]
                 (assoc curve-path-info
-                       :stroke-dasharray c-length
+                       :stroke-dasharray [(* misile-size c-length) (* (- 1 misile-size) c-length)]
                        :stroke-dashoffset (- c-length (* c-length clip-perc))))
-
+ 
               ;; normal curves
               curve-path-info)]]))
 
@@ -143,6 +144,10 @@
         params @(subscribe [:ui/parameters])]
     (when analysis-data
       [:g {}
+       ;; for debugging the data view-box
+       #_(let [{:keys [x1 y1 x2 y2]} (events.maps/get-analysis-objects-view-box analysis-data)]
+         [:rect {:x x1 :y y1 :width (- x2 x1) :height (- y2 y1) :stroke :red :stroke-width 0.1 :fill :transparent}])
+       
        (for [primitive-object analysis-data]
          ^{:key (str (:id primitive-object))}
          [map-primitive-object primitive-object scale time params])])))
@@ -228,13 +233,13 @@
 
            ;; map background
            [:rect {:x "0" :y "0" :width "100%" :height "100%" :fill "#ECEFF8"}]
-          
+
            ;; map and data svg
            [:g {:transform (gstr/format "translate(%f %f) scale(%f %f)"
                                         (or translate-x 0)
                                         (or translate-y 0)
-                                        scale scale)}
-            [:svg {:view-box "0 0 360 180"}
+                                        scale scale)}            
+            [:svg {:view-box "0 0 360 180" :preserve-aspect-ratio "xMinYMin"}
              [map-group]
              [data-group]]]
 

--- a/src/cljs/analysis_viewer/views.cljs
+++ b/src/cljs/analysis_viewer/views.cljs
@@ -21,12 +21,12 @@
 ;; as svg elements                                                                            ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defn svg-point-object [{:keys [coord show-start show-end radius-factor]} _ time-perc _]
+(defn svg-point-object [{:keys [coord show-start show-end radius]} scale time-perc _]
   (let [show? (<= show-start time-perc show-end)
         [x1 y1] coord]
     ;; TODO: add attrs
     [:g {:style {:display (if show? :block :none)}}
-     [:circle {:cx x1 :cy y1 :r (* 0.3 (or radius-factor 1)) #_(/ 0.4 scale) :stroke "#DD0808" :fill "#B20707"}]]))
+     [:circle {:cx x1 :cy y1 :r (or radius 0.1) :opacity 0.2 :fill "#B20707"}]]))
 
 (defn svg-area-object [{:keys [coords show-start show-end]} _ time-perc params]
   (let [show? (<= show-start time-perc show-end)]
@@ -56,14 +56,14 @@
         misile-size 0.3]
     ;; TODO: add attrs
     [:g {:style {:display (if show? :block :none)}}
-     [:circle {:cx x1 :cy y1 :r 0.3 #_(/ 0.4 scale) :stroke :red :fill :blue}] 
-     [:circle {:cx x2 :cy y2 :r 0.3 #_(/ 0.4 scale) :stroke :red :fill :blue}]
+     [:circle {:cx x1 :cy y1 :r 0.05 #_(/ 0.4 scale)  :fill :blue}] 
+     [:circle {:cx x2 :cy y2 :r 0.05 #_(/ 0.4 scale)  :fill :blue}]
      [:path (if clip-perc
 
               ;; animated dashed curves
-              (let [c-length (int (math-utils/quad-curve-length x1 y1 f1x f1y x2 y2))]
+              (let [c-length (math-utils/quad-curve-length x1 y1 f1x f1y x2 y2)]
                 (assoc curve-path-info
-                       :stroke-dasharray [(* misile-size c-length) (* (- 1 misile-size) c-length)]
+                       :stroke-dasharray c-length #_[(* misile-size c-length) (* (- 1 misile-size) c-length)]
                        :stroke-dashoffset (- c-length (* c-length clip-perc))))
  
               ;; normal curves

--- a/src/cljs/analysis_viewer/views.cljs
+++ b/src/cljs/analysis_viewer/views.cljs
@@ -22,12 +22,12 @@
 ;; as svg elements                                                                            ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defn svg-point-object [{:keys [coord show-start show-end]} scale time-perc params]
+(defn svg-point-object [{:keys [coord show-start show-end radius-factor]} scale time-perc params]
   (let [show? (<= show-start time-perc show-end)
         [x1 y1] coord]
     ;; TODO: add attrs
     [:g {:style {:display (if show? :block :none)}}
-     [:circle {:cx x1 :cy y1 :r 0.3 #_(/ 0.4 scale) :stroke "#DD0808" :fill "#B20707"}]]))
+     [:circle {:cx x1 :cy y1 :r (* 0.3 (or radius-factor 1)) #_(/ 0.4 scale) :stroke "#DD0808" :fill "#B20707"}]]))
 
 (defn svg-area-object [{:keys [coords show-start show-end]} _ time-perc params]
   (let [show? (<= show-start time-perc show-end)]

--- a/src/cljs/analysis_viewer/views.cljs
+++ b/src/cljs/analysis_viewer/views.cljs
@@ -114,7 +114,7 @@
                                         animation-delta-t))}]
        [:i.zmdi.zmdi-skip-next {:on-click inc-time-fn} ""]]
       [:div.timeline {:width "100%" :height "100%"}
-       [:svg {:width "100%" :height "100%"}
+       [:svg {:width "100%" :height "100px"}
         [:g
          [:line {:x1 play-line-x :y1 0 
                  :x2 play-line-x :y2 100
@@ -161,89 +161,90 @@
       (let [{:keys [grab translate scale zoom-rectangle]} @(re-frame/subscribe [::subs/map-state])
             scale (or scale 1)
             [translate-x translate-y] translate]
-        [:div.animated-data-map {:style {} #_{:height (str events.maps/map-screen-height "px")
-                                              :width  (str events.maps/map-screen-width  "px")}
-                                 :on-wheel (fn [evt]
-                                             (let [x (-> evt .-nativeEvent .-offsetX)
-                                                   y (-> evt .-nativeEvent .-offsetY)]
-                                               (dispatch [:map/zoom {:delta (.-deltaY evt)
-                                                                     :x x
-                                                                     :y y}])))
-                                 :on-mouse-down (fn [evt]
-                                                  (.stopPropagation evt)
-                                                  (.preventDefault evt)
-                                                  (let [x (-> evt .-nativeEvent .-offsetX)
-                                                        y (-> evt .-nativeEvent .-offsetY)]
-                                                    (cond
+        [:div.animated-data-map
+         [:div.map-wrapper {:style {} #_{:height (str events.maps/map-screen-height "px")
+                                        :width  (str events.maps/map-screen-width  "px")}
+                           :on-wheel (fn [evt]
+                                       (let [x (-> evt .-nativeEvent .-offsetX)
+                                             y (-> evt .-nativeEvent .-offsetY)]
+                                         (dispatch [:map/zoom {:delta (.-deltaY evt)
+                                                               :x x
+                                                               :y y}])))
+                           :on-mouse-down (fn [evt]
+                                            (.stopPropagation evt)
+                                            (.preventDefault evt)
+                                            (let [x (-> evt .-nativeEvent .-offsetX)
+                                                  y (-> evt .-nativeEvent .-offsetY)]
+                                              (cond
 
-                                                      ;; left button pressed
-                                                      (= left-button (.-button evt))                                  
-                                                      (dispatch [:map/grab {:x x :y y}])
+                                                ;; left button pressed
+                                                (= left-button (.-button evt))                                  
+                                                (dispatch [:map/grab {:x x :y y}])
 
-                                                      ;; wheel button pressed
-                                                      (= wheel-button (.-button evt))
-                                                      (dispatch [:map/zoom-rectangle-grab {:x x :y y}]))))
-                                 
-                                 :on-mouse-move (fn [evt]
-                                                  (let [x (-> evt .-nativeEvent .-offsetX)
-                                                        y (-> evt .-nativeEvent .-offsetY)]
-                                                    (cond
-                                                      grab
-                                                      (dispatch [:map/drag {:x x :y y}])
+                                                ;; wheel button pressed
+                                                (= wheel-button (.-button evt))
+                                                (dispatch [:map/zoom-rectangle-grab {:x x :y y}]))))
+                           
+                           :on-mouse-move (fn [evt]
+                                            (let [x (-> evt .-nativeEvent .-offsetX)
+                                                  y (-> evt .-nativeEvent .-offsetY)]
+                                              (cond
+                                                grab
+                                                (dispatch [:map/drag {:x x :y y}])
 
-                                                      zoom-rectangle
-                                                      (dispatch [:map/zoom-rectangle-update {:x x :y y}]))))
-                                 :on-mouse-up (fn [evt]
-                                                (.stopPropagation evt)
-                                                (.preventDefault evt)
-                                                (cond
-                                                  (= left-button (.-button evt))
-                                                  (dispatch [:map/grab-release])
+                                                zoom-rectangle
+                                                (dispatch [:map/zoom-rectangle-update {:x x :y y}]))))
+                           :on-mouse-up (fn [evt]
+                                          (.stopPropagation evt)
+                                          (.preventDefault evt)
+                                          (cond
+                                            (= left-button (.-button evt))
+                                            (dispatch [:map/grab-release])
 
-                                                  (= wheel-button (.-button evt))
-                                                  (dispatch [:map/zoom-rectangle-release])))}
-         [:div.zoom-bar-outer
-          [:div.zoom-bar-back]
-          [zoom-bar {:zoom-perc (- 100 (/ (* 100 scale) events.maps/max-scale ))
-                     :zoom-inc-fn #(dispatch [:map/zoom {:delta -50
-                                                         :x (/ events.maps/map-screen-width 2)
-                                                         :y (/ events.maps/map-screen-height 2)}])
-                     :zoom-dec-fn #(dispatch [:map/zoom {:delta 50
-                                                         :x (/ events.maps/map-screen-width 2)
-                                                         :y (/ events.maps/map-screen-height 2)}])
-                     :class "map-zoom"}]]
-         
-         ;; SVG data map
-         [:svg {:xmlns "http://www.w3.org/2000/svg"
-                :xmlns:amcharts "http://amcharts.com/ammap"
-                :xmlnsXlink "http://www.w3.org/1999/xlink"
-                :version "1.1"
-                :width "100%"
-                :height "100%"
-                :id "map-and-data"}
-
-          ;; gradients definitions
-          [:defs {}
-           [:linearGradient {:id "grad"}
-            [:stop {:offset "0%" :stop-color "#DD0808"}]
-            [:stop {:offset "100%" :stop-color "#B20707"}]]]
-
-          ;; map background
-          [:rect {:x "0" :y "0" :width "100%" :height "100%" :fill "#ECEFF8"}]
+                                            (= wheel-button (.-button evt))
+                                            (dispatch [:map/zoom-rectangle-release])))}
+          [:div.zoom-bar-outer
+           [:div.zoom-bar-back]
+           [zoom-bar {:zoom-perc (- 100 (/ (* 100 scale) events.maps/max-scale ))
+                      :zoom-inc-fn #(dispatch [:map/zoom {:delta -50
+                                                          :x (/ events.maps/map-screen-width 2)
+                                                          :y (/ events.maps/map-screen-height 2)}])
+                      :zoom-dec-fn #(dispatch [:map/zoom {:delta 50
+                                                          :x (/ events.maps/map-screen-width 2)
+                                                          :y (/ events.maps/map-screen-height 2)}])
+                      :class "map-zoom"}]]
           
-          ;; map and data svg
-          [:g {:transform (gstr/format "translate(%f %f) scale(%f %f)"
-                                       (or translate-x 0)
-                                       (or translate-y 0)
-                                       scale scale)}
-           [:svg {:view-box "0 0 360 180"}
-            [map-group]
-            [data-group @time-ref]]]
+          ;; SVG data map
+          [:svg {:xmlns "http://www.w3.org/2000/svg"
+                 :xmlns:amcharts "http://amcharts.com/ammap"
+                 :xmlnsXlink "http://www.w3.org/1999/xlink"
+                 :version "1.1"
+                 :width "100%"
+                 :height "100%"
+                 :id "map-and-data"}
 
-          (when zoom-rectangle
-            (let [[x1 y1] (:origin zoom-rectangle)
-                  [x2 y2] (:current zoom-rectangle)]
-              [:rect {:x x1 :y y1 :width (- x2 x1) :height (- y2 y1) :stroke "#DD0808" :fill :transparent}]))]
+           ;; gradients definitions
+           [:defs {}
+            [:linearGradient {:id "grad"}
+             [:stop {:offset "0%" :stop-color "#DD0808"}]
+             [:stop {:offset "100%" :stop-color "#B20707"}]]]
+
+           ;; map background
+           [:rect {:x "0" :y "0" :width "100%" :height "100%" :fill "#ECEFF8"}]
+           
+           ;; map and data svg
+           [:g {:transform (gstr/format "translate(%f %f) scale(%f %f)"
+                                        (or translate-x 0)
+                                        (or translate-y 0)
+                                        scale scale)}
+            [:svg {:view-box "0 0 360 180"}
+             [map-group]
+             [data-group @time-ref]]]
+
+           (when zoom-rectangle
+             (let [[x1 y1] (:origin zoom-rectangle)
+                   [x2 y2] (:current zoom-rectangle)]
+               [:rect {:x x1 :y y1 :width (- x2 x1) :height (- y2 y1) :stroke "#DD0808" :fill :transparent}]))]]
          [animation-controls {:dec-time-fn dect
                               :inc-time-fn inct
                               :time-ref time-ref}]]))))

--- a/src/cljs/analysis_viewer/views.cljs
+++ b/src/cljs/analysis_viewer/views.cljs
@@ -3,6 +3,7 @@
   Also handles animations."
   (:require [analysis-viewer.subs :as subs]
             [analysis-viewer.events.maps :as events.maps]
+            [analysis-viewer.components :refer [switch-button]]
             [analysis-viewer.svg-renderer :as svg-renderer]
             [clojure.string :as str]
             [goog.string :as gstr]
@@ -281,6 +282,12 @@
       ^{:key (str (:id c))}
       [collapsible-tab id c])]])
 
+(defn layer-visibility []
+  [:div.layer-visibility
+   [:label "Borders"]    [switch-button {:id :map-borders}]
+   [:label "Directions"] [switch-button {:id :directions}]
+   [:label "Radius"]     [switch-button {:id :radius}]])
+
 (defn map-color-chooser []
   (let [colors ["#079DAB" "#3428CA" "#757295" "#DD0808" "#EEBE53" "#B20707" "#ECEFF8" "#FBFCFE" "#DEDEE9"
                 "#266C08" "#C76503" "#1C58D0" "#A5387B" "#1C58D9" "#3A3668" "#757299" "#DEDEE8" "#3428CB"]
@@ -304,7 +311,7 @@
                        :id :parameters
                        :childs [{:title "Layer visibility"
                                  :id :layer-visibility
-                                 :child [:div "XXXXXXX"]}
+                                 :child [layer-visibility]}
                                 {:title "Map Color"
                                  :id :map-color
                                  :child [map-color-chooser]}


### PR DESCRIPTION
This PR includes : 
- Use analysisType from output file instead of url
- Add support for displaying bayes analysis output
- Add support for displaying discrete tree analysis outputs
- Fix set-view-box by using rendered map width instead of hardcoded one
- Move animation systems from ratoms to re-frame
- Add switch-button and slider components
- Add map color chooser
- Add zoom-bar for the map
- Fix area map rendering
- Attributes visualization
- Left bar supports different tools per analysis type