### PR TITLE
flatten

### DIFF
--- a/src/main/java/com/spread/data/Layer.java
+++ b/src/main/java/com/spread/data/Layer.java
@@ -14,20 +14,26 @@ public class Layer {
 
     @Getter
     private final List<Point> points;
-
     @Getter
     private final List<Line> lines;
-
     @Getter
     private final List<Area> areas;
+    @Getter
+    private List<Point> counts;
 
     public static class Builder {
 
         private List<Point> points;
         private List<Line> lines;
         private List<Area> areas;
+        private List<Point> counts;
 
         public Builder() {
+        }
+
+        public Builder withCounts(List<Point> counts) {
+            this.counts = counts;
+            return this;
         }
 
         public Builder withPoints(List<Point> points) {
@@ -53,6 +59,7 @@ public class Layer {
     }
 
     private Layer(Builder builder) {
+        this.counts = builder.counts;
         this.points = builder.points;
         this.lines = builder.lines;
         this.areas = builder.areas;

--- a/src/main/java/com/spread/parsers/DiscreteTreeParser.java
+++ b/src/main/java/com/spread/parsers/DiscreteTreeParser.java
@@ -368,13 +368,13 @@ public class DiscreteTreeParser implements IProgressReporter {
 
         LinkedList<Layer> layersList = new LinkedList<Layer>();
 
-        Layer countsLayer = new Layer.Builder ().withPoints (countsList).build ();
-
-        layersList.add(countsLayer);
+        // Layer countsLayer = new Layer.Builder ().withPoints (countsList).build ();
+        // layersList.add(countsLayer);
 
         Layer treeLayer = new Layer.Builder ()
             .withPoints (pointsList)
             .withLines (linesList)
+            .withCounts (countsList)
             .build ();
 
         layersList.add(treeLayer);

--- a/src/test/java/com/spread/DiscreteTreeParserTest.java
+++ b/src/test/java/com/spread/DiscreteTreeParserTest.java
@@ -72,12 +72,9 @@ public class DiscreteTreeParserTest {
         assertEquals("returns correct x coordinate", 118.283, loc.getCoordinate().getXCoordinate(), 0.0);
         assertEquals("returns correct x coordinate", 25.917, loc.getCoordinate().getYCoordinate(), 0.0);
 
-        // assertEquals("first layer is counts", Layer.Type.counts, data.getLayers().get(0).getType());
-        assertEquals("returns correct number of Points in Layer", 20, data.getLayers().get(0).getPoints().size());
-
-        // assertEquals("second layer is tree", Layer.Type.tree, data.getLayers().get(1).getType());
-        assertEquals("returns correct number of points", 51, data.getLayers().get(1).getPoints().size());
-        assertEquals("returns correct number of lines", 30, data.getLayers().get(1).getLines().size());
+        assertEquals("returns correct number of counts", 20, data.getLayers().get(0).getCounts().size ());
+        assertEquals("returns correct number of points", 51, data.getLayers().get(0).getPoints().size());
+        assertEquals("returns correct number of lines", 30, data.getLayers().get(0).getLines().size());
     }
 
 }


### PR DESCRIPTION
### Summary

Simplify SpreadData format by flattening discrete-mcc-tree output. Count are now part of the first (and only) layer.