### PR TITLE
Fix #21 Introduce sql transactions

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -75,7 +75,7 @@
 
   :lint
   {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2021.09.25"}}
-   :main-opts  ["-m" "clj-kondo.main" "--lint src/clj"]}
+   :main-opts  ["-m" "clj-kondo.main" "--lint" "src/clj"]}
 
   :repl
   {:extra-deps {refactor-nrepl/refactor-nrepl {:mvn/version "2.5.0"}}}

--- a/src/clj/api/config.clj
+++ b/src/clj/api/config.clj
@@ -50,7 +50,7 @@
 
      :google
      {:client-id     (or (get-env-variable "GOOGLE_CLIENT_ID") "806052757605-5sbubbk9ubj0tq95dp7b58v36tscqv1r.apps.googleusercontent.com")
-      :client-secret (or (get-env-variable "GOOGLE_CLIENT_SECRET") client-secret)}
+      :client-secret (or client-secret (get-env-variable "GOOGLE_CLIENT_SECRET"))}
 
      :sendgrid
      {:template-id "d-02dda5f4b9e94948aedcec04b0e37abc"
@@ -59,4 +59,4 @@
      :public-key
      (or (get-env-variable "PUBLIC_KEY")
          "-----BEGIN PUBLIC KEY-----\nMFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBAJliLjOIAqGbnjGBM1RJml/l0MHayaRH\ncgEg00O9wBYvoNXrstFSzKTCKtG5MayUKgdG7C/98nu/TEzhvRFjINcCAwEAAQ==\n-----END PUBLIC KEY-----\n")
-     :private-key (or (get-env-variable "PRIVATE_KEY") private-key)}))
+     :private-key (or private-key (get-env-variable "PRIVATE_KEY"))}))


### PR DESCRIPTION
Added transactions to API and Workers

The approach on API is to wrap every request in a transaction and commit before returning the response unless an exception happened.

Pros: You don't need to think about transactions on mutations
Cons: You kind of need to think about transactions on mutations because you need to remember to bubble up the exceptions.

The other way is to just wrap statements in a tx with jdbc/wrap-transaction , but is not easy to remember or figure out in cases like :
```clojure
(fn do-foo []
  (insert! ...))

(fn do-bar []
  (insert! ...))

(fn store-something []
  ;; since you don't see db modifications here is easy to
  ;; forget to wrap this two into a TX
  (do-foo)
  (do-bar))
```
