### PR TITLE
Change animation speed system to animation desired duration

### DIFF
--- a/services/analysis-viewer/css/main.css
+++ b/services/analysis-viewer/css/main.css
@@ -346,7 +346,7 @@ button {
 	left: 10px;
 }
 
-.animation-controls .speed-slider {
+.animation-controls .desired-duration-slider {
     height: 80% !important;
 }
 

--- a/src/cljs/analysis_viewer/db.cljs
+++ b/src/cljs/analysis_viewer/db.cljs
@@ -162,7 +162,7 @@
                :height nil}
    :animation/frame-timestamp 0
    :animation/crop [0 1]
-   :animation/desired-duration 10000 ;; 10 seconds
+   :animation/desired-duration 10 ;; 10 seconds
    :animation/state :stop
    :analysis.data/filters {}
    :ui.collapsible-tabs/tabs {:layer-visibility true,

--- a/src/cljs/analysis_viewer/db.cljs
+++ b/src/cljs/analysis_viewer/db.cljs
@@ -105,7 +105,7 @@
 (s/def :animation/frame-timestamp number?)
 (s/def :animation/state #{:stop :play})
 (s/def :animation/crop (s/tuple number? number?))
-(s/def :animation/speed (s/and number? #(<= 1 % 200)))  ;; days/second
+(s/def :animation/desired-duration (s/and number? #(<= 1 %)))
 (s/def :analysis/selected-object-id :analysis.data.object/id)
 (s/def :analysis/highlighted-object-id (s/nilable :analysis.data.object/id))
 (s/def :analysis/possible-objects-ids (s/coll-of :analysis.data.object/id))
@@ -137,7 +137,7 @@
 (s/def ::db (s/keys :req [:map/state
                           :animation/frame-timestamp
                           :animation/state
-                          :animation/speed
+                          :animation/desired-duration
                           :animation/crop
                           :ui.switch-buttons/states
                           :ui/parameters
@@ -162,7 +162,7 @@
                :height nil}
    :animation/frame-timestamp 0
    :animation/crop [0 1]
-   :animation/speed 10
+   :animation/desired-duration 10000 ;; 10 seconds
    :animation/state :stop
    :analysis.data/filters {}
    :ui.collapsible-tabs/tabs {:layer-visibility true,

--- a/src/cljs/analysis_viewer/events.cljs
+++ b/src/cljs/analysis_viewer/events.cljs
@@ -51,7 +51,7 @@
 (reg-event-fx :animation/update-frame-timestamp [] events.maps/animation-update-frame-timestamp)
 (reg-event-fx :animation/finished [] events.maps/animation-finished)
 (reg-event-db :animation/set-crop [sc] events.maps/animation-set-crop)
-(reg-event-fx :animation/set-speed [sc] events.maps/animation-set-speed)
+(reg-event-fx :animation/set-desired-duration [sc] events.maps/animation-set-desired-duration)
 
 (reg-event-db :filters/add-attribute-filter [sc] events.filters/add-attribute-filter)
 (reg-event-db :filters/rm-attribute-filter [sc] events.filters/rm-attribute-filter)

--- a/src/cljs/analysis_viewer/fxs.cljs
+++ b/src/cljs/analysis_viewer/fxs.cljs
@@ -125,7 +125,7 @@
                                    (reset! start-time* t)
                                    1))
 
-                       curr-frame-timestamp (+ date-from (* (/ elapsed desired-duration)
+                       curr-frame-timestamp (+ date-from (* (/ elapsed (* 1000 desired-duration))
                                                             date-range-millis))]
 
                    ;; every `report-freq-millis` report to the re-frame db so the ui can keep track of

--- a/src/cljs/analysis_viewer/subs.cljs
+++ b/src/cljs/analysis_viewer/subs.cljs
@@ -38,9 +38,9 @@
    (:animation/crop db)))
 
 (reg-sub
- :animation/speed
+ :animation/desired-duration
  (fn [db _]
-   (:animation/speed db)))
+   (:animation/desired-duration db)))
 
 (reg-sub
  :analysis/date-range

--- a/src/cljs/analysis_viewer/subs.cljs
+++ b/src/cljs/analysis_viewer/subs.cljs
@@ -40,7 +40,7 @@
 (reg-sub
  :animation/desired-duration
  (fn [db _]
-   (:animation/desired-duration db)))
+   (int (:animation/desired-duration db))))
 
 (reg-sub
  :analysis/date-range

--- a/src/cljs/analysis_viewer/subs.cljs
+++ b/src/cljs/analysis_viewer/subs.cljs
@@ -255,18 +255,31 @@
           start-year (.getUTCFullYear start-date)
           end-month (.getUTCMonth end-date) ; 0-11
           end-year   (.getUTCFullYear end-date)
-          ticks (let [all-ticks (->> (range start-year (inc end-year))
-                                     (mapcat (fn [year]
-                                               (-> (repeatedly 11 (fn [] {:label nil :type :short}))
-                                                   (into [{:label (str year) :type :long}]))))
+          years-span (- end-year start-year)
+          ticks (let [months-ticks? (< years-span 5)
+                      year-lbl-multiple-of (cond
+                                           (<= years-span 20) 1
+                                           (<= 21 years-span 40) 5
+                                           (>= years-span 41) 10)
+                      years (range start-year (inc end-year))
+                      all-ticks (->> (mapcat (fn [year]
+                                               (let [year-lbl (when (zero? (mod year year-lbl-multiple-of))
+                                                                (str year))]
+                                                 (cond-> [{:label year-lbl :type :long}]
+                                                   months-ticks? (into (repeatedly 11 (fn [] {:label nil :type :short}))))))
+                                             years)
                                      (into []))]
-                  ;; all-ticks are months for the years range.
-                  ;; Since data doesn't start in Jan and ends on Dec we need to cut
-                  ;; some months from the beginning of first year and the end of the last year
-                  (subvec all-ticks
-                          start-month
-                          (min (inc (- (count all-ticks) (- 11 end-month))) ; the outer inc is because subvec exclusive in the end
-                               (count all-ticks))))  ; clamp it so we don't try to show "after december"
+                  (if months-ticks?
+                    ;; all-ticks are months for the years range.
+                    ;; Since data doesn't start in Jan and ends on Dec we need to cut
+                    ;; some months from the beginning of first year and the end of the last year
+
+                    (subvec all-ticks
+                            start-month
+                            (min (inc (- (count all-ticks) (- 11 end-month))) ; the outer inc is because subvec exclusive in the end
+                                 (count all-ticks)))  ; clamp it so we don't try to show "after december"
+                    all-ticks))
+
           ticks-cnt (count ticks)
           margin 50
           tick-gap (when (and timeline-px-width (pos? ticks-cnt))

--- a/src/cljs/analysis_viewer/views.cljs
+++ b/src/cljs/analysis_viewer/views.cljs
@@ -157,7 +157,8 @@
 (defn timeline []
   (let [crop-sides 20
         ticks-y-base 80
-        timeline-start crop-sides
+        timeline-left-margin 10
+        timeline-start (+ timeline-left-margin crop-sides)
         update-after-render (fn [div-cmp]
                               (let [dom-node (rdom/dom-node div-cmp)
                                     brect (.getBoundingClientRect dom-node)]

--- a/src/cljs/analysis_viewer/views.cljs
+++ b/src/cljs/analysis_viewer/views.cljs
@@ -217,10 +217,10 @@
     ;; the entire map is being redraw, making some animations a lot less smooth.
     ;; {:contain :strict} prevents just that, tells the browser that changes inside this element shouldn't affect elements outside.
     [:div.animation-controls {:style {:contain :strict}}
-     [mui-slider {:inc-buttons 1000
+     [mui-slider {:inc-buttons 1
                   :class "desired-duration-slider"
                   :min-val 1
-                  :max-val 300000 ;; 5 minutes max
+                  :max-val 300 ;; 5 minutes max
                   :vertical? true
                   :subs-vec [:animation/desired-duration]
                   :ev-vec [:animation/set-desired-duration]}]
@@ -228,7 +228,7 @@
        [:div.loading "Loading..."]
        [:div.inner
         [:div.hud
-         [:div.speed (gstr/format "Total animation duration: %d sec" (/ desired-duration 1000))]
+         [:div.speed (gstr/format "Total animation duration: %d sec" desired-duration)]
          [:div.date (str "Date: " (ui-utils/format-date frame-timestamp))]]
         [:div.buttons
          [:i.zmdi.zmdi-skip-previous {:on-click #(dispatch [:animation/reset :start])} ""]

--- a/src/cljs/analysis_viewer/views.cljs
+++ b/src/cljs/analysis_viewer/views.cljs
@@ -210,25 +210,25 @@
 
 (defn animation-controls []
   (let [frame-timestamp @(subscribe [:animation/frame-timestamp])
-        speed @(subscribe [:animation/speed])
+        desired-duration @(subscribe [:animation/desired-duration])
         playing? (= :play @(subscribe [:animation/state]))]
 
     ;; IMPORTANT ! For some reason in chrome when the animation-controls get updated (when :animation/frame-timestamp) changes for example,
     ;; the entire map is being redraw, making some animations a lot less smooth.
     ;; {:contain :strict} prevents just that, tells the browser that changes inside this element shouldn't affect elements outside.
     [:div.animation-controls {:style {:contain :strict}}
-     [mui-slider {:inc-buttons 0.8
-                  :class "speed-slider"
+     [mui-slider {:inc-buttons 1000
+                  :class "desired-duration-slider"
                   :min-val 1
-                  :max-val 70
+                  :max-val 300000 ;; 5 minutes max
                   :vertical? true
-                  :subs-vec [:animation/speed]
-                  :ev-vec [:animation/set-speed]}]
+                  :subs-vec [:animation/desired-duration]
+                  :ev-vec [:animation/set-desired-duration]}]
      (if (zero? frame-timestamp)
        [:div.loading "Loading..."]
        [:div.inner
         [:div.hud
-         [:div.speed (gstr/format "Speed: %d days/sec" speed)]
+         [:div.speed (gstr/format "Total animation duration: %d sec" (/ desired-duration 1000))]
          [:div.date (str "Date: " (ui-utils/format-date frame-timestamp))]]
         [:div.buttons
          [:i.zmdi.zmdi-skip-previous {:on-click #(dispatch [:animation/reset :start])} ""]


### PR DESCRIPTION
The animation bar on the left that used to control animation speed now controls desired animation length in seconds. It has a range from 1 to 5min.

Animation single stepping controls now advance 1/50th of the total animation crop