### PR TITLE
upgrade build (to java11) and runtime (to java17)

### DIFF
--- a/services/db-migration/pom.xml
+++ b/services/db-migration/pom.xml
@@ -10,8 +10,8 @@
   <url>http://maven.apache.org</url>
 
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <liquibase.version>3.8.7</liquibase.version>
   </properties>

--- a/services/db-migration/serverless.yml
+++ b/services/db-migration/serverless.yml
@@ -10,7 +10,7 @@ provider:
   region: us-east-2
   stage: prod
   deploymentBucket: spread-${self:custom.stage}-serverlessdeploymentbucket
-  runtime: java8
+  runtime: java17
   logRetentionInDays: 14
 
 functions:


### PR DESCRIPTION
### Summary

AWS retires java8 runtimes for lambdas
