### PR TITLE
Fix/#223

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The diagram below presents an overview of the architecture of spread:
 ### Start all
 
 Make sure you have [tmux](https://github.com/tmux/tmux) multiplexer installed.
-Execute `./start_all_components` in your temrinal window and it will start all the components in separate tmux windows.
+Execute `./start_all_components` in your terminal window and it will start all the components in separate tmux windows.
 
 ### Backend services
 

--- a/src/cljs/ui/new_analysis/continuous_mcc_tree.cljs
+++ b/src/cljs/ui/new_analysis/continuous_mcc_tree.cljs
@@ -80,7 +80,7 @@
                              :on-click #(>evt [:continuous-mcc-tree/delete-tree-file])}])]
 
            (cond
-             (contains? @field-errors :tree-file-error) [:div.field-error.button-error "Tree file incorrect format."]
+             (contains? @field-errors :tree-file-error) [:div.field-error.button-error (str "Tree file name is over " file-formats/name-length-limit " characters long or the file content has an incorrect format.")]
              (nil? tree-file-name) [:p.doc "When upload is complete all unique attributes will be automatically filled. You can then select geographical coordinates and change other settings."])]
 
           [:section.load-trees-file
@@ -104,7 +104,7 @@
                              :on-click #(>evt [:continuous-mcc-tree/delete-trees-file])}])]
 
            (cond
-             (contains? @field-errors :trees-file-error) [:div.field-error.button-error "Trees file incorrect format."]
+             (contains? @field-errors :trees-file-error) [:div.field-error.button-error (str "Trees file name is over " file-formats/name-length-limit " characters long or the file content has an incorrect format.")]
              (nil? trees-file-name) [:p.doc "Optional: Select a file with corresponding trees distribution. This file will be used to compute a density interval around the MCC tree."])]
 
           [:div.upload-spinner

--- a/src/cljs/ui/new_analysis/discrete_mcc_tree.cljs
+++ b/src/cljs/ui/new_analysis/discrete_mcc_tree.cljs
@@ -75,7 +75,7 @@
               [loaded-input {:value    tree-file-name
                              :on-click #(>evt [:discrete-mcc-tree/delete-tree-file])}])]
            (cond
-             (contains? @field-errors :tree-file-error) [:div.field-error.button-error "Tree file incorrect format."]
+             (contains? @field-errors :tree-file-error) [:div.field-error.button-error (str "Tree file name is over " file-formats/name-length-limit " characters long or the file content has an incorrect format.")]
              (nil? tree-file-name)                      [:p.doc "When upload is complete all unique attributes will be automatically filled. You can then select location attribute and change other settings."])]
 
           [:section.load-locations-file
@@ -99,7 +99,7 @@
               [loaded-input {:value    locations-file-name
                              :on-click #(>evt [:discrete-mcc-tree/delete-locations-file])}])]
            (cond
-             (contains? @field-errors :locations-file-error) [:div.field-error.button-error "Locations file first row doesn't contain all numbers."]
+             (contains? @field-errors :locations-file-error) [:div.field-error.button-error (str "Locations file name is over " file-formats/name-length-limit " characters or the file content has an incorrect format.")]
              (nil? locations-file-name)                      [:p.doc "Select a file that maps geographical coordinates to the log file columns. Once this file is uploaded you can start your analysis."])]
           [:div.upload-spinner
            (when (and (= 1 tree-file-upload-progress) (nil? attribute-names))

--- a/src/cljs/ui/new_analysis/discrete_rates.cljs
+++ b/src/cljs/ui/new_analysis/discrete_rates.cljs
@@ -66,7 +66,7 @@
               [loaded-input {:value    log-file-name
                              :on-click #(>evt [:bayes-factor/delete-log-file])}])]
            (cond
-             (contains? @field-errors :log-file-error) [:div.field-error.button-error "Log file first row doesn't contain all numbers."]
+             (contains? @field-errors :log-file-error) [:div.field-error.button-error (str "Log file name is over " file-formats/name-length-limit " or the file content has an incorrect format.")]
              (nil? log-file-name)                      [:p.doc "Upload log file. You can then upload a matching coordinates file."])]
           [:section.load-locations-file
            [:div
@@ -87,7 +87,7 @@
               [loaded-input {:value    locations-file-name
                              :on-click #(>evt [:bayes-factor/delete-locations-file])}])]
            (cond
-             (contains? @field-errors :locations-file-error) [:div.field-error.button-error "Locations file first row doesn't contain all numbers."]
+             (contains? @field-errors :locations-file-error) [:div.field-error.button-error (str "Locations file name is over " file-formats/name-length-limit " characters or the file content has an incorrect format.")]
              (nil? locations-file-name)                      [:p.doc "Select a file that maps geographical coordinates to the log file columns. Once this file is uploaded you can start your analysis."])]
 
           (when (and log-file-name

--- a/src/cljs/ui/new_analysis/file_formats.cljs
+++ b/src/cljs/ui/new_analysis/file_formats.cljs
@@ -52,6 +52,9 @@
       (.then (fn [file-content]
                (try
                  (let [map-json (js/JSON.parse file-content)]
-                   (and (<= (count (.-name file)) 200) ;; see db.changelog-9.0.xml
+                   (and
+                     ;; limit is 200 (see db.changelog-9.0.xml)
+                     ;; but we set it to 50 for consistency
+                     (<= (count (.-name file)) name-length-limit)
                      (boolean (#{"FeatureCollection" "Feature"} (.-type map-json)))))
                  (catch js/Error _ false))))))

--- a/src/cljs/ui/new_analysis/file_formats.cljs
+++ b/src/cljs/ui/new_analysis/file_formats.cljs
@@ -1,13 +1,17 @@
 (ns ui.new-analysis.file-formats
   (:require [clojure.string :as str]))
 
+;; see db.changelog-8.0.xml
+(def ^:const name-length-limit 50)
+
 (defn b->Mb [b]
   (-> b (/ 1024) (/ 1024)))
 
 (defn tree-file-accept-predicate [{:keys [file size]}]
   (-> (.text (.slice file 0 6))
       (.then (fn [first-bytes-str]
-               (and (= first-bytes-str "#NEXUS")
+               (and (<= (count (.-name file)) name-length-limit)
+                    (= first-bytes-str "#NEXUS")
                     (<= (b->Mb size) 150))))))
 
 (def trees-file-accept-predicate tree-file-accept-predicate)
@@ -15,30 +19,32 @@
 (defn log-file-accept-predicate [{:keys [file]}]
   (let [log-head-size 3000]
     (-> (.text (.slice file 0 log-head-size))
-       (.then (fn [file-head-str]
-                ;; `file-head-str` containts 3Kb of the log file
-                ;; The acceptance criteria is that the first row should contain all numbers
-                ;; First row is counted after skipping comments and headers
-                (let [first-row (->> (str/split-lines file-head-str)
-                                     (drop-while #(str/starts-with? % "#")) ;; drop the comments
-                                     rest ;; drop the headers
-                                     first)]
-                  (->> (str/split first-row #"[\t\s]")
-                       (remove str/blank?)
-                       (every? #(not (js/isNaN (js/parseFloat %)))))))))))
+        (.then (fn [file-head-str]
+                 ;; `file-head-str` containts 3Kb of the log file
+                 ;; The acceptance criteria is that the first row should contain all numbers
+                 ;; First row is counted after skipping comments and headers
+                 (let [first-row (->> (str/split-lines file-head-str)
+                                      (drop-while #(str/starts-with? % "#")) ;; drop the comments
+                                      rest ;; drop the headers
+                                      first)]
+                   (and (<= (count (.-name file)) name-length-limit)
+                        (->> (str/split first-row #"[\t\s]")
+                             (remove str/blank?)
+                             (every? #(not (js/isNaN (js/parseFloat %))))))))))))
 
 (defn locations-file-accept-predicate [{:keys [file]}]
   (-> (.text file) ;; this will load the entire coordinates file in memory but they look pretty small (~1Kb)
       (.then (fn [file-content]
                (try
-                 (let [first-line (-> file-content
-                                     (str/split-lines)
-                                     first)
-                      [l n1 n2] (-> first-line
-                                    (str/split #"[\t\s]"))]
-                  (and (string? l)
-                       (not (js/isNaN (js/parseFloat n1)))
-                       (not (js/isNaN (js/parseFloat n2)))))
+                 (let [first-line       (-> file-content
+                                      (str/split-lines)
+                                      first)
+                       [location n1 n2] (-> first-line
+                                            (str/split #"[\t\s]"))]
+                   (and (<= (count (.-name file)) name-length-limit)
+                        (string? location)
+                        (not (js/isNaN (js/parseFloat n1)))
+                        (not (js/isNaN (js/parseFloat n2)))))
                  (catch js/Error _ false))))))
 
 (defn custom-map-file-accept-predicate [{:keys [file]}]
@@ -46,5 +52,6 @@
       (.then (fn [file-content]
                (try
                  (let [map-json (js/JSON.parse file-content)]
-                   (boolean (#{"FeatureCollection" "Feature"} (.-type map-json))))
+                   (and (<= (count (.-name file)) 200) ;; see db.changelog-9.0.xml
+                     (boolean (#{"FeatureCollection" "Feature"} (.-type map-json)))))
                  (catch js/Error _ false))))))

--- a/src/cljs/ui/new_analysis/file_formats.cljs
+++ b/src/cljs/ui/new_analysis/file_formats.cljs
@@ -54,7 +54,8 @@
                  (let [map-json (js/JSON.parse file-content)]
                    (and
                      ;; limit is 200 (see db.changelog-9.0.xml)
-                     ;; but we set it to 50 for consistency
+                     ;; but we check it to 50 for consistency
+                     ;; this column could be migrated at some point
                      (<= (count (.-name file)) name-length-limit)
                      (boolean (#{"FeatureCollection" "Feature"} (.-type map-json)))))
                  (catch js/Error _ false))))))


### PR DESCRIPTION
### Summary

closes #223 (and #216).

### Review notes
Type for custom_map/file_name is constrained at 200 characters. 
Technically we should migrate it to a VARCHAR 50 for consistency with other name columns, but I'm just too lazy after a long vacay period.
